### PR TITLE
docs: add KMASS metrics and metadata operations model

### DIFF
--- a/docs/coc-service-catalog-and-kpis.md
+++ b/docs/coc-service-catalog-and-kpis.md
@@ -1,0 +1,95 @@
+# CoC Service Catalog and KPI Mapping
+
+## Purpose
+
+This document maps the CoC service model into DelEx using business-facing service areas, outcome expectations, and KPI families.
+
+## Service catalog
+
+### Engagement
+Service areas:
+- communication
+- evangelism
+- adoption
+
+Representative KPIs:
+- number of events, presentations, or talks
+- incoming business requests
+- workshop quality and workshop conversion
+- number of ambassadors
+- business units using solutions
+- total end-users reached
+
+### Strategy and Planning
+Service areas:
+- program management
+- strategic model
+
+Representative KPIs:
+- budget allocated
+- cycle time by phase
+- geographies or business lines impacted
+- stakeholder feedback
+- time to production
+- ideas versus prototypes versus production solutions
+- partnerships and best-practice adherence
+
+### Information Technology and Solution Design
+Service areas:
+- exploration and experimentation
+- solutioning
+
+Representative KPIs:
+- failure rate of custom technical development
+- technologies experimented with
+- solutions transferred to delivery
+- value of custom build relative to effort
+- assurance review cycle time
+- repeatable versus one-off solution mix
+
+### Transformation
+Service areas:
+- business value
+- design, validate, and transition
+- demand generation
+
+Representative KPIs:
+- projected and actualized financial value
+- reusability of use cases
+- use-case backlog
+- CVA cycle time
+- validated use cases
+- generated expansion insights
+
+### Delivery
+Service areas:
+- implementation
+- integration
+- run and maintain
+
+Representative KPIs:
+- code and content quality
+- projects delivered
+- time from implementation to production
+- integration complexity
+- platform downtime
+- incident volume and issue resolution time
+- responsiveness and user satisfaction
+- time to update technology or data
+
+## Rule of integration
+
+Business-facing CoC KPIs should not float separately from DelEx control objects.
+
+Each service area should be tied to:
+- named owners
+- delivery gates
+- evidence artifacts
+- metric contracts
+- reusable assets where applicable
+
+## Metric layering
+
+The CoC KPI layer describes what the service must achieve.
+The KMASS metric layer describes how technical quality, friction, and scale are measured underneath that service.
+The DelEx control layer governs approvals, exceptions, escalation, and evidence.

--- a/docs/kmass-metrics-v1.md
+++ b/docs/kmass-metrics-v1.md
@@ -1,0 +1,111 @@
+# KMASS Metrics v1
+
+## Purpose
+
+This document turns the KMASS framework into a DelEx-governed measurement contract.
+
+The goal is to make outcome, capacity, and friction claims precise enough to be audited, tested, versioned, and attached to phase-gate acceptance.
+
+## Metric contract columns
+
+Each metric entry should define:
+- metric id
+- figure row / human-readable label
+- metric type
+- unit
+- phase targets
+- measurement protocol
+- acceptable error or confidence rule
+- required evidence artifacts
+
+## Canonical metric set
+
+| Metric ID | Figure Row | Type | Unit | Phase Targets | Evidence Artifact |
+|---|---|---|---|---|---|
+| `TAB.TEXT.GRAN` | Textual Granularity | Outcome | Top-1 accuracy @ unit | 80% @ {doc, para, sentence} | labeled query set + retrieval logs |
+| `TAB.VIDEO.GRAN` | Video Granularity | Outcome | Success@5 or Recall@5 | 65% @ {video, clip, frame} | labeled multimodal queries + ranked outputs |
+| `TAB.TEXT.SCALE` | Text Sources | Capacity | count | 20k / 120k / 800k | ingestion manifests + index cardinalities |
+| `TAB.VIDEO.SCALE` | Video Sources | Capacity | hours | 40 / 220 / 400 | media catalog + segment index |
+| `TAC.CAPTURE.FRICTION` | Easy and Natural | Friction | minutes / fact | 10 / 5 / 2 | timestamped capture traces |
+| `TAD.LATENCY.JIT` | Just-in-Time | Outcome | seconds | 60 / 8 / 1 | end-to-end timing traces |
+| `TAD.ACTIONS.JE` | Just-enough | Friction | action count | 10 / 5 / 1 | UI or agent action logs |
+| `TAD.RELEVANCE.JFM` | Just-for-me | Outcome | percent relevant | 70 / 83 / 98 | human evaluation + rubric |
+| `SYS.SPEEDUP` | Speed Improvement | Composite | multiplier | 1.1x / 2x / 5x | time-on-task studies |
+| `SYS.SCALE.TBD` | Scale | Composite | multi-dimensional | TBD / TBD / TBD | policy/task/role graph stats |
+
+## Retrieval-unit canon
+
+### Text
+- Document: immutable source blob identified by `doc_id` and `doc_rev`
+- Paragraph: contiguous text span identified by `span_id = hash(doc_id, start_offset, end_offset)`
+- Sentence: linguistic segment with explicit `segmenter_ver`
+
+### Video
+- Video: `video_id` with `duration_ms`
+- Clip: `clip_id = hash(video_id, start_ms, end_ms)` with approximately 60-second span and explicit tolerance
+- Frame: `(video_id, frame_index)` with `fps_assumed` and `decode_method_version`
+
+## Measurement protocols
+
+### Text accuracy
+- metric: Top-1 exact match against labeled target set
+- granularity: document, paragraph, sentence
+- minimum sample size: 30 queries per phase per modality unless explicitly marked preliminary
+
+### Video retrieval success
+- metric: Success@5 or Recall@5
+- matching rule: overlap against labeled temporal target window, ideally with explicit IoU threshold
+
+### Relevance
+- metric: percentage of results scored relevant under blinded human evaluation
+- recommended rubric: 0 to 3, where score >= 2 counts as relevant
+
+### Latency and actions
+- latency: end-to-end query to answer completion time
+- actions: discrete user or agent actions required to reach acceptable answer state
+
+## Architecture commitments by phase
+
+### Phase 1
+- coarse indices
+- document-level and video-level retrieval
+- ranking and timing logs mandatory from day one
+
+### Phase 2
+- chunking pipeline with stable paragraph and clip identifiers
+- reranking on local context windows
+- basic role or task context for personalization
+
+### Phase 3
+- sentence-level or frame-level atomic provenance
+- aggressive caching and precomputation
+- context binding to identity, policy, and task state
+
+## Scale model
+
+Track at minimum:
+- `|K|`: number of knowledge elements
+- `|E|`: number of relations or provenance edges
+- `|P(task)|`: policies per task
+- `|CoP|`: communities of practice and role distributions
+- task throughput by role and CoP
+
+## Implementation profiles
+
+### Minimal
+- document and paragraph text indexing
+- clip-level video indexing, frame-level only for cited clips
+- stable provenance IDs required
+
+### Maximal
+- sentence-level atomic claims and claim normalization
+- frame-level indexing with temporal grounding
+- precomputation and caching for near-instant response
+
+## Gate implication
+
+No phase should be marked complete unless the metrics for that phase are attached to:
+- a named measurement protocol
+- evidence artifacts
+- an acceptance threshold
+- a reproducible run log

--- a/docs/metadata-operations-coc.md
+++ b/docs/metadata-operations-coc.md
@@ -1,0 +1,105 @@
+# Metadata Operations CoC
+
+## Purpose
+
+This document integrates operational metadata work into the DelEx Center of Capability model as a recurring service, not a one-time cleanup activity.
+
+It formalizes how metadata completeness, inconsistency remediation, contact verification, glossary quality, and BTNR handling should operate inside the broader governance, delivery, and continuous-improvement system.
+
+## Why metadata operations belong in the CoC
+
+The CoC success criteria require:
+- customer service focus and business-community buy-in
+- early planning in the implementation lifecycle
+- service-level expectations and measurement
+- explicit central-versus-distributed ownership
+- formal documentation and knowledge capture
+- strong governance to control cost and demonstrate value
+- motivated and coached staff
+- use of technology to reduce friction
+
+Operational metadata work directly serves those goals when treated as a governed service line.
+
+## Service placement in the CoC model
+
+### Engagement
+- verify metadata contacts
+- onboard metadata focals
+- run intro package and AMG demo sessions
+- collect engagement and adoption signals
+
+### Strategy and Planning
+- define metadata operating model
+- define central vs distributed ownership
+- define metadata SLA and escalation policy
+- define glossary and BTNR governance
+- plan staffing and retention for metadata capability
+
+### Information Technology and Solution Design
+- define report taxonomies and finding classes
+- define sync, schema, and naming inconsistency handling
+- define metadata quality dashboards
+- design validators and automation around findings
+
+### Transformation
+- connect metadata quality to benefit cases and funding readiness
+- prioritize use cases and sources based on business value and operational risk
+- create backlog and sprint packages from report findings
+
+### Delivery / Run and Maintain
+- execute remediation stories and subtasks
+- track completeness, inconsistency backlog, aging, SLA attainment, and reopen rates
+- run glossary quality and BTNR disposition routines
+- operate escalation path when engagement breaks down
+
+## Operational streams
+
+### Completeness stream
+Focus on metadata presence and coverage.
+
+Canonical checks:
+- metadata contacts verified
+- technical metadata present
+- business metadata present
+- red/yellow/green status assigned
+
+### Inconsistency stream
+Focus on structural, sync, and record-integrity discrepancies.
+
+Canonical finding classes include:
+- tabs_without_columns
+- schema_without_app
+- schema_without_table
+- schema_without_table_oos
+- schemas_missing_in_igc
+- out_of_sync_column
+- metadata_contact_inconsistency
+- data_artifact_inconsistency
+- glossary_quality_issue
+- btnr_candidate
+
+## TMD and BMD definitions
+
+### TMD
+Technical metadata is present when required technical description fields are populated, such as long and short descriptions.
+
+### BMD
+Business metadata is present when required business-term assignments are populated.
+
+## Governance rule
+
+Metadata operations are not a side queue. They are part of the governed delivery system and must be visible in:
+- service catalog
+- gate evidence requirements
+- dashboard snapshots
+- backlog and sprint packages
+- reusable playbooks and enablement assets
+
+## Evidence expectation
+
+No metadata completion or remediation claim is valid unless it is backed by:
+- a report or evaluation snapshot
+- a named owner or target role
+- a timestamped remediation action
+- an auditable status change
+- a reproducible dashboard or log artifact

--- a/docs/metadata-sla-escalation-model.md
+++ b/docs/metadata-sla-escalation-model.md
@@ -1,0 +1,70 @@
+# Metadata SLA and Escalation Model
+
+## Purpose
+
+This document defines the service-level and escalation model for metadata operations inside DelEx.
+
+The objective is to turn report-driven remediation into a governed service with explicit response expectations, breach logic, and escalation discipline.
+
+## Service-level model
+
+Each metadata finding class should carry:
+- severity
+- owner role
+- response SLA
+- remediation SLA
+- evidence required for closure
+- escalation trigger
+
+## Default severity model
+
+### Critical
+Use when the issue blocks production use, gate progression, or materially affects enterprise risk.
+
+### High
+Use when the issue materially affects delivery quality, business metadata trust, or sync correctness.
+
+### Medium
+Use when the issue degrades metadata quality but has workarounds.
+
+### Low
+Use when the issue is informational, cosmetic, or deferred by policy.
+
+## Example SLA posture
+
+| Severity | Response SLA | Remediation SLA | Escalation |
+|---|---|---|---|
+| Critical | 1 business day | 1 sprint or immediate hot-path action | immediate management escalation |
+| High | 2 business days | 1 to 2 sprints | escalate on missed response or low engagement |
+| Medium | 5 business days | backlog-managed | escalate on aging or repeated reopen |
+| Low | next planning cycle | discretionary | usually none unless trend worsens |
+
+## Engagement-based escalation rule
+
+Escalation should not be triggered solely by red or yellow status. It should be triggered when:
+- there is sustained red or yellow status
+- metadata contact is not verified
+- onboarding or engagement indicators are absent
+- response SLA is breached
+- remediation SLA is breached
+- the same issue reopens repeatedly
+
+## Closure evidence
+
+A finding should not be closed unless there is auditable evidence of:
+- ownership confirmation
+- corrective action
+- status change in the source system or metadata registry
+- report revalidation or dashboard confirmation
+
+## BTNR and glossary notes
+
+BTNR and glossary-related issues require separate policy interpretation, but they should still inherit:
+- severity
+- owner role
+- closure evidence
+- escalation trigger
+
+## Governance rule
+
+Escalation is part of service management, not interpersonal escalation theater. The goal is to recover delivery and metadata quality, not merely to signal dissatisfaction.


### PR DESCRIPTION
## Summary

Canonize the measurement and metadata-operations layer inside DelEx.

## Adds

- `docs/kmass-metrics-v1.md`
- `docs/metadata-operations-coc.md`
- `docs/metadata-sla-escalation-model.md`
- `docs/coc-service-catalog-and-kpis.md`

## Why

This PR integrates three previously separate strands into the DelEx canon:
1. the CoC / CoE business operating model
2. the KMASS formal metric contract
3. the operational metadata remediation handbook

Together they define the service model, control model, and measurement/remediation model that downstream repos and the automation contract layer should consume.

## Follow-up

- the corresponding machine-readable objects and validators are being added on the still-open `delivery-excellence-automation` PR #3
- once that PR merges, the canon/contract/consumer chain will be aligned on metrics, metadata operations, escalation, and SLA semantics
