### PR TITLE
Add Professional Intelligence delivery model

### DIFF
--- a/docs/professional-intelligence-control-register.md
+++ b/docs/professional-intelligence-control-register.md
@@ -54,7 +54,10 @@ As of 2026-04-29:
 - `SocioProphet/policy-fabric#34`: Professional Policy Decision schema and examples.
 - `SocioProphet/contractforge#4`: Obligation Ledger examples and validation.
 - `SocioProphet/global-devsecops-intelligence#10`: governance and control-plane assessment.
-- `SocioProphet/prophet-platform-fabric-mlops-ts-suite#31`: naming consistency cleanup.
+
+## Out-of-scope for this wave
+
+- `SocioProphet/prophet-platform-fabric-mlops-ts-suite` remains out of scope for this Professional Intelligence OS alignment wave. Profit/trading-bot naming in that repo is intentional and must not be treated as SocioProphet naming drift.
 
 ## Hygiene rules
 
@@ -63,7 +66,7 @@ As of 2026-04-29:
 3. Every PR states validation, evidence, and downstream impact.
 4. Demo credit requires evidence and adoption telemetry paths.
 5. Use the available environments before adding repos.
-6. Use `SocioProphet` consistently across public and operator-facing surfaces.
+6. Use `SocioProphet` consistently across public and operator-facing surfaces, while preserving intentional Profit/trading-bot naming in out-of-scope repos.
 
 ## Gates
 

--- a/docs/professional-intelligence-control-register.md
+++ b/docs/professional-intelligence-control-register.md
@@ -8,13 +8,17 @@ This register is the DelEx control surface for the current Professional Intellig
 
 As of 2026-04-29:
 
-- Overall alignment: 21%
+- Overall alignment: 23%
 - Architecture spine: 35%
-- DelEx governance: 35%
+- DelEx governance: 42%
 - DelEx automation: 25%
 - Platform contracts: 30%
 - Governed execution substrate: 22%
-- Workspace, search, and query surface: 12%
+- Workspace, search, and query surface: 14%
+- UI and dashboard integration: 8%
+- Sociosphere topology integration: 22%
+- Governance loops: 25%
+- Cybernetic controls: 16%
 - Playbooks: 18%
 - Runtime implementation: 5%
 - Demo readiness: 10%
@@ -22,18 +26,22 @@ As of 2026-04-29:
 ## Current PR wave
 
 - `SocioProphet/prophet-platform#263`: platform strategy, manifest, and seed contracts.
-- `SocioProphet/delivery-excellence#5`: delivery model.
+- `SocioProphet/delivery-excellence#5`: delivery model and control register.
 - `SocioProphet/delivery-excellence-automation#4`: automation schemas.
 - `SocioProphet/delivery-excellence-innersource#5`: playbook seeds.
 - `SocioProphet/policy-fabric#33`: policy integration boundary.
 - `SocioProphet/contractforge#3`: obligation ledger boundary.
 - `SocioProphet/prophet-workspace#7`: professional workroom boundary.
+- `SocioProphet/socioprophet#300`: UI and dashboard integration definition.
+- `SocioProphet/sociosphere#221`: topology and managed repo map.
 
 ## Current work orders
 
+- `mdheller/socioprophet-web#17`: dashboard MVP.
 - `SocioProphet/prophet-platform#269`: manifest and schema validation.
 - `SocioProphet/delivery-excellence-automation#5`: fixtures and CI validation.
 - `SocioProphet/delivery-excellence-innersource#6`: playbook linting.
+- `SocioProphet/delivery-excellence-boards#5`: program board lanes and rollup.
 - `SocioProphet/prophet-workspace#8`: workroom contract and fixture.
 - `SocioProphet/agentplane#72`: workflow bundle and evidence mapping.
 - `SocioProphet/agent-registry#5`: agent specs and tool grants.
@@ -43,6 +51,10 @@ As of 2026-04-29:
 - `SocioProphet/model-governance-ledger#6`: model and action evidence examples.
 - `SocioProphet/sherlock-search#19`: search packet contract and fixture.
 - `SocioProphet/prophet-core-query#2`: query contract for context inputs.
+- `SocioProphet/policy-fabric#34`: Professional Policy Decision schema and examples.
+- `SocioProphet/contractforge#4`: Obligation Ledger examples and validation.
+- `SocioProphet/global-devsecops-intelligence#10`: governance and control-plane assessment.
+- `SocioProphet/prophet-platform-fabric-mlops-ts-suite#31`: naming consistency cleanup.
 
 ## Hygiene rules
 
@@ -51,6 +63,7 @@ As of 2026-04-29:
 3. Every PR states validation, evidence, and downstream impact.
 4. Demo credit requires evidence and adoption telemetry paths.
 5. Use the available environments before adding repos.
+6. Use `SocioProphet` consistently across public and operator-facing surfaces.
 
 ## Gates
 

--- a/docs/professional-intelligence-control-register.md
+++ b/docs/professional-intelligence-control-register.md
@@ -8,38 +8,38 @@ This register is the DelEx control surface for the current Professional Intellig
 
 As of 2026-04-29:
 
-- Overall alignment: 23%
-- Architecture spine: 35%
+- Overall alignment: 28%
+- Architecture spine: 40%
 - DelEx governance: 42%
-- DelEx automation: 25%
-- Platform contracts: 30%
+- DelEx automation: 45%
+- Platform contracts: 45%
 - Governed execution substrate: 22%
 - Workspace, search, and query surface: 14%
 - UI and dashboard integration: 8%
 - Sociosphere topology integration: 22%
 - Governance loops: 25%
-- Cybernetic controls: 16%
+- Cybernetic controls: 20%
 - Playbooks: 18%
 - Runtime implementation: 5%
-- Demo readiness: 10%
+- Demo readiness: 14%
 
 ## Current PR wave
 
-- `SocioProphet/prophet-platform#263`: platform strategy, manifest, and seed contracts.
-- `SocioProphet/delivery-excellence#5`: delivery model and control register.
-- `SocioProphet/delivery-excellence-automation#4`: automation schemas.
-- `SocioProphet/delivery-excellence-innersource#5`: playbook seeds.
-- `SocioProphet/policy-fabric#33`: policy integration boundary.
-- `SocioProphet/contractforge#3`: obligation ledger boundary.
-- `SocioProphet/prophet-workspace#7`: professional workroom boundary.
-- `SocioProphet/socioprophet#300`: UI and dashboard integration definition.
-- `SocioProphet/sociosphere#221`: topology and managed repo map.
+- `SocioProphet/prophet-platform#263`: merged. Platform strategy, manifest, seed contracts, examples, and validation.
+- `SocioProphet/delivery-excellence#5`: open. Delivery model and control register.
+- `SocioProphet/delivery-excellence-automation#4`: merged. Automation schemas, examples, validation, and CI wiring.
+- `SocioProphet/delivery-excellence-innersource#5`: open. Playbook seeds.
+- `SocioProphet/policy-fabric#33`: open. Policy integration boundary.
+- `SocioProphet/contractforge#3`: open. Obligation ledger boundary.
+- `SocioProphet/prophet-workspace#7`: open. Professional workroom boundary.
+- `SocioProphet/socioprophet#300`: open. UI and dashboard integration definition.
+- `SocioProphet/sociosphere#221`: open. Topology and managed repo map.
 
 ## Current work orders
 
 - `mdheller/socioprophet-web#17`: dashboard MVP.
-- `SocioProphet/prophet-platform#269`: manifest and schema validation.
-- `SocioProphet/delivery-excellence-automation#5`: fixtures and CI validation.
+- `SocioProphet/prophet-platform#269`: completed. Manifest and schema validation.
+- `SocioProphet/delivery-excellence-automation#5`: completed. Fixtures and CI validation.
 - `SocioProphet/delivery-excellence-innersource#6`: playbook linting.
 - `SocioProphet/delivery-excellence-boards#5`: program board lanes and rollup.
 - `SocioProphet/prophet-workspace#8`: workroom contract and fixture.
@@ -70,10 +70,10 @@ As of 2026-04-29:
 
 ## Gates
 
-Gate 1: merge alignment docs and seed contracts. Target overall: 25%.
+Gate 1: merge alignment docs and seed contracts. Target overall: 25%. Status: substantially complete; remaining open boundary PRs still need review/merge.
 
-Gate 2: add validation fixtures. Target overall: 32%.
+Gate 2: add validation fixtures. Target overall: 32%. Status: active; platform and DelEx automation validation are complete, playbook/workroom/policy/obligation validation remains.
 
-Gate 3: create runnable demo slice. Target overall: 45%.
+Gate 3: create runnable demo slice. Target overall: 45%. Status: not yet runnable.
 
-Gate 4: produce first integrated demo. Target overall: 60%.
+Gate 4: produce first integrated demo. Target overall: 60%. Status: not yet runnable.

--- a/docs/professional-intelligence-control-register.md
+++ b/docs/professional-intelligence-control-register.md
@@ -8,30 +8,30 @@ This register is the DelEx control surface for the current Professional Intellig
 
 As of 2026-04-29:
 
-- Overall alignment: 28%
+- Overall alignment: 32%
 - Architecture spine: 40%
-- DelEx governance: 42%
+- DelEx governance: 45%
 - DelEx automation: 45%
 - Platform contracts: 45%
 - Governed execution substrate: 22%
-- Workspace, search, and query surface: 14%
-- UI and dashboard integration: 8%
+- Workspace, search, and query surface: 25%
+- UI and dashboard integration: 18%
 - Sociosphere topology integration: 22%
 - Governance loops: 25%
-- Cybernetic controls: 20%
-- Playbooks: 18%
+- Cybernetic controls: 22%
+- Playbooks: 35%
 - Runtime implementation: 5%
-- Demo readiness: 14%
+- Demo readiness: 23%
 
 ## Current PR wave
 
 - `SocioProphet/prophet-platform#263`: merged. Platform strategy, manifest, seed contracts, examples, and validation.
 - `SocioProphet/delivery-excellence#5`: open. Delivery model and control register.
 - `SocioProphet/delivery-excellence-automation#4`: merged. Automation schemas, examples, validation, and CI wiring.
-- `SocioProphet/delivery-excellence-innersource#5`: open. Playbook seeds.
+- `SocioProphet/delivery-excellence-innersource#5`: merged. Playbook seeds, schema, validation, and CI wiring.
 - `SocioProphet/policy-fabric#33`: open. Policy integration boundary.
 - `SocioProphet/contractforge#3`: open. Obligation ledger boundary.
-- `SocioProphet/prophet-workspace#7`: open. Professional workroom boundary.
+- `SocioProphet/prophet-workspace#7`: merged. Professional workroom boundary, contract, fixture, validation, and CI wiring.
 - `SocioProphet/socioprophet#300`: open. UI and dashboard integration definition.
 - `SocioProphet/sociosphere#221`: open. Topology and managed repo map.
 
@@ -40,9 +40,9 @@ As of 2026-04-29:
 - `mdheller/socioprophet-web#17`: dashboard MVP.
 - `SocioProphet/prophet-platform#269`: completed. Manifest and schema validation.
 - `SocioProphet/delivery-excellence-automation#5`: completed. Fixtures and CI validation.
-- `SocioProphet/delivery-excellence-innersource#6`: playbook linting.
+- `SocioProphet/delivery-excellence-innersource#6`: completed. Playbook linting.
 - `SocioProphet/delivery-excellence-boards#5`: program board lanes and rollup.
-- `SocioProphet/prophet-workspace#8`: workroom contract and fixture.
+- `SocioProphet/prophet-workspace#8`: completed. Workroom contract and fixture.
 - `SocioProphet/agentplane#72`: workflow bundle and evidence mapping.
 - `SocioProphet/agent-registry#5`: agent specs and tool grants.
 - `SocioProphet/model-router#5`: routing policy examples.
@@ -70,9 +70,9 @@ As of 2026-04-29:
 
 ## Gates
 
-Gate 1: merge alignment docs and seed contracts. Target overall: 25%. Status: substantially complete; remaining open boundary PRs still need review/merge.
+Gate 1: merge alignment docs and seed contracts. Target overall: 25%. Status: complete for platform, automation, playbooks, and workspace; boundary PRs for policy, obligations, UI, and topology remain open.
 
-Gate 2: add validation fixtures. Target overall: 32%. Status: active; platform and DelEx automation validation are complete, playbook/workroom/policy/obligation validation remains.
+Gate 2: add validation fixtures. Target overall: 32%. Status: reached for platform, DelEx automation, playbooks, and workrooms; policy and obligation validation remain.
 
 Gate 3: create runnable demo slice. Target overall: 45%. Status: not yet runnable.
 

--- a/docs/professional-intelligence-control-register.md
+++ b/docs/professional-intelligence-control-register.md
@@ -1,0 +1,63 @@
+# Professional Intelligence OS Control Register
+
+## Purpose
+
+This register is the DelEx control surface for the current Professional Intelligence OS alignment wave. It keeps the work bounded, reviewable, and tied to acceptance criteria.
+
+## Completion readout
+
+As of 2026-04-29:
+
+- Overall alignment: 21%
+- Architecture spine: 35%
+- DelEx governance: 35%
+- DelEx automation: 25%
+- Platform contracts: 30%
+- Governed execution substrate: 22%
+- Workspace, search, and query surface: 12%
+- Playbooks: 18%
+- Runtime implementation: 5%
+- Demo readiness: 10%
+
+## Current PR wave
+
+- `SocioProphet/prophet-platform#263`: platform strategy, manifest, and seed contracts.
+- `SocioProphet/delivery-excellence#5`: delivery model.
+- `SocioProphet/delivery-excellence-automation#4`: automation schemas.
+- `SocioProphet/delivery-excellence-innersource#5`: playbook seeds.
+- `SocioProphet/policy-fabric#33`: policy integration boundary.
+- `SocioProphet/contractforge#3`: obligation ledger boundary.
+- `SocioProphet/prophet-workspace#7`: professional workroom boundary.
+
+## Current work orders
+
+- `SocioProphet/prophet-platform#269`: manifest and schema validation.
+- `SocioProphet/delivery-excellence-automation#5`: fixtures and CI validation.
+- `SocioProphet/delivery-excellence-innersource#6`: playbook linting.
+- `SocioProphet/prophet-workspace#8`: workroom contract and fixture.
+- `SocioProphet/agentplane#72`: workflow bundle and evidence mapping.
+- `SocioProphet/agent-registry#5`: agent specs and tool grants.
+- `SocioProphet/model-router#5`: routing policy examples.
+- `SocioProphet/guardrail-fabric#6`: guardrail pack.
+- `SocioProphet/memory-mesh#11`: scoped context-pack support.
+- `SocioProphet/model-governance-ledger#6`: model and action evidence examples.
+- `SocioProphet/sherlock-search#19`: search packet contract and fixture.
+- `SocioProphet/prophet-core-query#2`: query contract for context inputs.
+
+## Hygiene rules
+
+1. Every change maps to a platform capability.
+2. Every agent task is represented by an issue or PR.
+3. Every PR states validation, evidence, and downstream impact.
+4. Demo credit requires evidence and adoption telemetry paths.
+5. Use the available environments before adding repos.
+
+## Gates
+
+Gate 1: merge alignment docs and seed contracts. Target overall: 25%.
+
+Gate 2: add validation fixtures. Target overall: 32%.
+
+Gate 3: create runnable demo slice. Target overall: 45%.
+
+Gate 4: produce first integrated demo. Target overall: 60%.

--- a/docs/professional-intelligence-delivery-model.md
+++ b/docs/professional-intelligence-delivery-model.md
@@ -1,0 +1,181 @@
+# Professional Intelligence Delivery Model
+
+## Purpose
+
+This document makes DelEx-OS the delivery governance spine for the SocioProphet Professional Intelligence OS program.
+
+DelEx does not own product runtime. DelEx owns the way work enters, moves, proves itself, and gets accepted across the repo estate.
+
+## Delivery chain
+
+Professional Intelligence OS work follows this chain:
+
+```
+Signal -> Intake -> Board Item -> ADR / Spec -> Repo Work Order -> PR -> Validation -> Evidence -> Demo Acceptance -> KPI Update
+```
+
+## Control points
+
+### 1. Signal
+
+Sources may include customer discovery, competitive analysis, architecture gaps, repo audits, incidents, interview prep, platform demos, or agent findings.
+
+Required fields:
+- signal id
+- source type
+- confidence
+- impacted capability
+- impacted repos
+- decision required
+
+### 2. Intake
+
+Intake normalizes the signal into a DelEx work item.
+
+Required fields:
+- title
+- problem statement
+- desired outcome
+- capability area
+- owner repo
+- runtime repo
+- governance repo
+- acceptance evidence
+- demo impact
+- risk class
+
+### 3. Board item
+
+The board item is the visible delivery unit. It must map to a Professional Intelligence OS capability in `SocioProphet/prophet-platform/professional-intelligence.manifest.yaml`.
+
+Allowed capability classes:
+- institution-context-engine
+- institution-graph
+- agent-fabric
+- conflict-engine
+- obligation-ledger
+- ethical-walls
+- workspace-os
+- adoption-telemetry
+- evidence-plane
+- revenue-integrity
+- vertical-pack
+- delivery-governance
+
+### 4. ADR / Spec
+
+Any cross-repo or irreversible decision requires an ADR or spec.
+
+ADR/spec must state:
+- decision
+- repos affected
+- rejected alternatives
+- implementation owner
+- validation path
+- rollback path
+- evidence requirements
+
+### 5. Repo work order
+
+A repo work order gives an agent or human contributor a bounded implementation target.
+
+A valid work order includes:
+- branch name
+- files to create or modify
+- commands to validate
+- acceptance evidence
+- related playbook
+- related schema or contract
+- expected PR target
+
+### 6. PR
+
+Every PR should include:
+- capability mapping
+- validation performed
+- evidence artifacts produced or updated
+- demo impact
+- risk/rollback notes
+- downstream repos to update
+
+### 7. Validation
+
+Validation must include repository-local checks and, when relevant, cross-repo manifest checks.
+
+Minimum validation tiers:
+- docs-only: link and manifest sanity
+- contracts: schema validation and examples
+- service: unit/smoke checks
+- platform: runtime smoke and GitOps surface checks
+- demo: playbook-driven evidence and adoption event
+
+### 8. Evidence
+
+Evidence must be machine-readable where possible.
+
+Evidence may include:
+- validation report
+- adoption event
+- policy check receipt
+- agent action receipt
+- replay artifact
+- demo acceptance receipt
+- repo readiness report
+
+### 9. Demo acceptance
+
+A demo is accepted only when it can show:
+- an executable playbook or equivalent scripted workflow
+- institution context resolution
+- governed agent/tool action
+- policy or obligation check
+- workspace effect
+- adoption event
+- evidence receipt
+- KPI movement or measurable proxy
+
+### 10. KPI update
+
+DelEx KPIs should track:
+- demo readiness
+- repo readiness
+- playbook coverage
+- validation pass rate
+- evidence coverage
+- adoption telemetry coverage
+- cycle-time reduction
+- risk closure
+- customer/value hypothesis coverage
+
+## Repo family alignment
+
+- `delivery-excellence`: mandate, KPI/OKR definitions, governance model, templates, acceptance rules.
+- `delivery-excellence-automation`: group/RBAC bindings, CI validation, generated ledgers, meeting/audience automation.
+- `delivery-excellence-boards`: idea intake, roadmap, delivery boards, portfolio state.
+- `delivery-excellence-innersource`: playbooks, repo readiness, contribution routes, portal/index specs.
+- `delivery-excellence-bounties`: acceleration policy, scoring, escrow/payout gates.
+
+## Initial program board lanes
+
+1. Runtime spine
+   - `prophet-platform`, `TriTRPC`, `tritfabric`, `prophet-cli`.
+
+2. Work surface
+   - `prophet-workspace`, `sherlock-search`, `speechlab`, `orion-field-intelligence`.
+
+3. Governed AI execution
+   - `agentplane`, `agent-registry`, `model-router`, `guardrail-fabric`, `model-governance-ledger`, `memory-mesh`.
+
+4. Policy, obligations, and risk
+   - `policy-fabric`, `contractforge`, `regis-entity-graph`, `ontogenesis`.
+
+5. Domain packs
+   - legal, private capital, real assets, revenue integrity, public-sector/research.
+
+## Non-negotiables
+
+- No orphan repo work. Every meaningful change maps to a capability and an acceptance path.
+- No platform feature without evidence and adoption telemetry.
+- No agent action without tool grants, authority boundary, and replay/evidence posture.
+- No playbook without policy/obligation and KPI hooks.
+- No demo that bypasses governance for speed.


### PR DESCRIPTION
## Summary

Adds the DelEx delivery governance model and control register for Professional Intelligence OS.

Adds:
- `docs/professional-intelligence-delivery-model.md`
- `docs/professional-intelligence-control-register.md`

The delivery model defines the chain:

`Signal -> Intake -> Board Item -> ADR / Spec -> Repo Work Order -> PR -> Validation -> Evidence -> Demo Acceptance -> KPI Update`

The control register tracks current PRs, Codex/Copilot work orders, completion percentages, hygiene rules, scope boundaries, and consolidation gates.

## Why

The SocioProphet estate has platform, agent, workspace, policy, model, contract, and search pieces. DelEx needs a stable operating model so work becomes measurable and accepted across repos without unmanaged fanout.

## Current completion readout

- Overall alignment: ~32%
- Architecture spine: ~40%
- DelEx governance: ~45%
- DelEx automation: ~45%
- Platform contracts: ~45%
- Workspace/search/query surface: ~25%
- Playbooks: ~35%
- Demo readiness: ~23%

## Validation

Docs/control-register tranche. The register references merged validation work in `prophet-platform`, `delivery-excellence-automation`, `delivery-excellence-innersource`, and `prophet-workspace`.