### PR TITLE
Add agent harness delivery operating model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,9 @@ Delivery Excellence (DelEx-OS) governance repository:
 - KPI/OKR definitions and scoreboards
 - templates (WoW items, ADRs, meeting outputs)
 
+## Current operating models
+
+- [Agent Harness Delivery Operating Model](docs/agent-harness-delivery-operating-model.md) — cross-estate performance stack for outcome-driven agent/human work, delivery metering, corporate scoreboards, operating cadence, customer proof, and reusable work packaging.
+
 Automation bindings (groups/email/calendars/workflow validation) live in:
 - SocioProphet/delivery-excellence-automation

--- a/docs/agent-harness-delivery-operating-model.md
+++ b/docs/agent-harness-delivery-operating-model.md
@@ -1,0 +1,322 @@
+# Agent Harness Delivery Operating Model
+
+Status: v0.1 planning baseline  
+Owner plane: Delivery Excellence / DelEx-OS  
+Scope: cross-estate performance stack, delivery metering, corporate scoreboards, operating cadence, customer proof, and agent/human work packaging
+
+## Why this exists
+
+Aden/Hive is useful as a competitive reference because it frames production agents as business-process infrastructure: describe an outcome, generate a plan/graph, run governed workers, observe cost and failure, preserve memory, involve humans, and evolve the process. That pattern is broader than software development. It applies to product delivery, security operations, customer proof, corporate reporting, bounty work, inner-source contribution, support workflows, finance/admin workflows, research production, and field operations.
+
+Delivery Excellence owns the operating and performance layer for this pattern. AgentPlane, Policy Fabric, SourceOS, BearBrowser, TurtleTerm, Memory Mesh, SCOPE-D, SocioSphere, and platform repos emit signals and evidence. Delivery Excellence turns those signals into scoreboards, operating cadence, work packaging, service-level expectations, executive readouts, and improvement loops.
+
+## Boundary
+
+Delivery Excellence owns:
+
+- KPI/OKR definitions and scoreboards.
+- Work-order and acceptance templates.
+- Delivery cadence, escalation, and operating reviews.
+- Performance readouts for agent/human work.
+- Customer-safe proof-of-value projections.
+- Bounty and inner-source work packaging rules.
+- Cross-estate readiness, hygiene, and completion metrics.
+- Management-system language for product, operations, support, and security teams.
+
+Delivery Excellence does not own:
+
+- Agent runtime execution. That remains AgentPlane.
+- Policy compilation and admission. That remains Policy Fabric / Guardrail Fabric.
+- Workspace topology authority. That remains SocioSphere.
+- SourceOS host/runtime implementation. That remains SourceOS / SociOS / Agent Machine repos.
+- Browser and terminal runtime behavior. That remains BearBrowser, TurtleTerm, and agent-term.
+- Security test execution. That remains SCOPE-D and security-specific repos.
+- Memory runtime implementation. That remains Memory Mesh.
+
+## Integration loop
+
+The cross-estate operating loop is:
+
+```text
+Outcome -> Work Item -> Plan Graph -> Policy Gate -> Run -> Evidence -> Scoreboard -> Review -> Evolution Patch -> Promotion Gate
+```
+
+Delivery Excellence owns the translation from evidence to management control:
+
+```text
+EvidencePack -> DeliveryMetric -> KPI/OKR -> Readout -> Decision -> Follow-up Work Item
+```
+
+## Core objects
+
+### Outcome
+
+A measurable business or platform result, not just a task. Required fields:
+
+- outcome id
+- owner
+- customer or stakeholder
+- expected value
+- success criteria
+- risk tier
+- due date or cadence
+- evidence requirements
+- linked repos
+- linked policy gates
+- linked run/evidence artifacts
+
+### Work Item
+
+A scoped unit of human or agent work. Required fields:
+
+- work item id
+- outcome ref
+- repo refs
+- execution mode: human, agent, paired, review-only, dry-run, autonomous-with-gate
+- assignee or worker class
+- acceptance criteria
+- validation path
+- rollback/abandon rule
+- evidence refs
+- readout lane
+
+### Delivery Metric
+
+A stable performance signal derived from evidence. Initial metric families:
+
+- throughput: completed work items, merged PRs, accepted patches, shipped templates
+- flow: cycle time, blocked time, review latency, gate latency, reopen rate
+- quality: validation pass rate, rollback rate, defect escape rate, evidence completeness
+- governance: policy gate pass/fail, exception count, human approval count, revocation count
+- cost: model cost, compute cost, human approval load, retry cost, wasted-run cost
+- reliability: run success rate, replay success rate, session resume rate, tool failure rate
+- safety/security: SCOPE-D findings, prompt/tool/skill/MCP risk count, secret/network violations
+- customer proof: value delivered, time saved, artifact count, approved outputs, SLA contribution
+
+### Readout
+
+A management-facing projection of delivery state. Required readout types:
+
+- operator readout: what changed, what passed, what failed, what is blocked
+- executive readout: outcome progress, risk, cost, confidence, next decision
+- customer-safe readout: work performed, evidence, value, approvals, known limits
+- repo readiness readout: maturity, validation, CI, hygiene, docs, open blockers
+- agent performance readout: agent class, tool grants, cost, success, intervention rate
+
+## Cross-estate signal producers
+
+### AgentPlane
+
+Emits validation, placement, run, replay, session, promotion, and reversal artifacts. Delivery Excellence consumes these as run success, replay readiness, cycle time, cost, and promotion-readiness signals.
+
+### Policy Fabric / Guardrail Fabric
+
+Emit policy decisions, guardrail evaluations, validation reports, exceptions, and replay reports. Delivery Excellence consumes these as governance pass/fail, exception burden, risk exposure, and approval latency.
+
+### SourceOS / Agent Machine / sourceos-spec
+
+Emit local-first service manifests, activation decisions, boot/release evidence, host readiness, signed release envelopes, and runtime receipts. Delivery Excellence consumes these as installability, bootstrap readiness, supply-chain posture, and local-first operational maturity.
+
+### BearBrowser
+
+Emits browser history/events, credential posture, automation-surface validation, build readiness, and governed browser action evidence. Delivery Excellence consumes these as browser automation reliability, credential safety, and workflow coverage.
+
+### TurtleTerm / agent-term / workstation contracts
+
+Emit shell receipts, operator smoke records, IPC conformance, terminal action evidence, and durable operator state. Delivery Excellence consumes these as operator UX readiness, terminal workflow reliability, and developer/operator parity.
+
+### Memory Mesh
+
+Emits context-pack refs, recall/writeback evidence, memory profile posture, sensitive-payload storage decisions, and retrieval behavior. Delivery Excellence consumes these as memory reliability, context quality, retention posture, and evidence traceability.
+
+### SCOPE-D
+
+Emits defensive security assessments for cloud, GitHub, Kubernetes, local hosts, MCP/tool servers, skills, memory stores, vector stores, graph robustness, detections, and threat intelligence. Delivery Excellence consumes these as security readiness, validation coverage, and risk burndown.
+
+### SocioSphere
+
+Emits workspace topology, repo inventory, dependency direction, source-exposure governance, integration status, and cross-repo hardening rules. Delivery Excellence consumes these as estate coverage, topology compliance, source exposure posture, and integration completeness.
+
+### Product/web/workspace surfaces
+
+SocioProphet product repos, SocioSphere, Prophet Workspace, and web surfaces expose customer/operator-facing status. Delivery Excellence consumes their evidence to produce proof-of-value, demo readiness, and public-product readiness scoreboards.
+
+## Recent active repo watchlist
+
+The operating model must track newly active or recently contributed repos, not only the older dossier baseline. As of the May 2026 alignment pass, include at least:
+
+- SocioProphet/superconscious
+- SocioProphet/agentplane
+- SocioProphet/policy-fabric
+- SocioProphet/guardrail-fabric
+- SocioProphet/model-router
+- SocioProphet/functional-model-surfaces
+- SocioProphet/model-governance-ledger
+- SocioProphet/prophet-platform
+- SocioProphet/prophet-workspace
+- SocioProphet/workspace-inventory
+- SocioProphet/ProCybernetica
+- SocioProphet/HolographMe
+- SocioProphet/semantic-serdes
+- SocioProphet/ontogenesis
+- SocioProphet/socioprophet-agent-standards
+- SocioProphet/SCOPE-D
+- SocioProphet/memory-mesh
+- SourceOS-Linux/agent-machine
+- SourceOS-Linux/BearBrowser
+- SourceOS-Linux/TurtleTerm
+- SourceOS-Linux/agent-term
+- SourceOS-Linux/sourceos-spec
+- SourceOS-Linux/homebrew-tap
+- SourceOS-Linux/sourceos-syncd
+- SociOS-Linux/source-os
+- SociOS-Linux/socios
+- SociOS-Linux/workstation-contracts
+- SociOS-Linux/embeddinglab
+- SociOS-Linux/graphlab
+- SociOS-Linux/nlplab
+- SociOS-Linux/timeserieslab
+- SociOS-Linux/translationlab
+- mdheller/socioprophet-web
+
+This list should become machine-generated by delivery-excellence-automation using recent commit, PR, issue, and workspace-inventory signals.
+
+## Aden/Hive lessons absorbed
+
+### Outcome-first delivery
+
+Do not track only tasks. Track business/platform outcomes and required evidence.
+
+### Graph-first operating model
+
+Plan graphs are useful for management visibility, not only runtime execution. Delivery boards should expose workstream graphs, dependency edges, approval gates, and live status.
+
+### Human-in-the-loop accounting
+
+Human approvals, rejections, overrides, clarifications, risk acceptances, and credential grants are not invisible interruptions. They are signed control events and must be counted.
+
+### Cost and failure as first-class signals
+
+Agent cost, retry cost, wasted-run cost, escalation load, tool failure, and replay failure must be visible in scoreboards.
+
+### Skill/MCP marketplace discipline
+
+Skills and MCP servers should be measured as reusable assets: installs, tests, trust tier, defects, risk findings, evidence examples, adoption, and deprecation status.
+
+### Proof-of-value
+
+Every significant workflow should have an internal and customer-safe readout: what work was done, what artifacts changed, what approvals occurred, what value was delivered, what risks remain, and what should happen next.
+
+## Initial scoreboards
+
+### Estate readiness scoreboard
+
+- repo has README
+- repo has AGENTS.md or equivalent agent instructions
+- repo has validation command
+- repo has CI validation
+- repo has maturity/status file
+- repo has security/reporting policy when relevant
+- repo is registered in SocioSphere/workspace-inventory
+- repo emits or consumes evidence
+- repo has owner and boundary statement
+
+### Agent harness scoreboard
+
+- outcome spec exists
+- plan graph exists
+- policy gate exists
+- run evidence exists
+- replay evidence exists
+- human approval events recorded
+- cost/budget recorded
+- failure diagnosis recorded
+- evolution patch or follow-up work item recorded
+- promotion decision recorded
+
+### Product proof scoreboard
+
+- demo path exists
+- one-command smoke path exists
+- stakeholder-readable summary exists
+- customer-safe summary exists
+- artifact index exists
+- digest/provenance present
+- known gaps documented
+- next decision documented
+
+### Skill/MCP scoreboard
+
+- manifest exists
+- trust tier assigned
+- policy grants declared
+- evals exist
+- risk/threat model exists
+- install/doctor command exists
+- evidence fixture exists
+- deprecation/revocation path exists
+
+## Cadence
+
+Weekly operating review:
+
+- top outcomes
+- completion percent by workstream
+- blockers and gate latency
+- failed validations and regressions
+- agent cost and intervention load
+- customer-safe proof updates
+- security/risk deltas
+- next 7-day decisions
+
+Daily lightweight review:
+
+- merged PRs
+- open high-risk PRs
+- failed CI
+- blocked work items
+- overdue approvals
+- stale evidence
+
+Release review:
+
+- outcome completion
+- validation and replay status
+- evidence completeness
+- SCOPE-D/security posture
+- rollback readiness
+- proof-of-value summary
+- promotion decision
+
+## Delivery Excellence automation requirements
+
+The automation repo should add or extend contracts for:
+
+- `recent-repo-activity-report`
+- `agent-harness-work-item`
+- `delivery-metric-event`
+- `scoreboard-snapshot`
+- `customer-proof-readout`
+- `human-control-event`
+- `skill-mcp-asset-score`
+- `repo-readiness-score`
+
+These contracts should allow CI and GitHub automation to ingest AgentPlane, Policy Fabric, SourceOS, SCOPE-D, Memory Mesh, BearBrowser, TurtleTerm, and SocioSphere signals without making Delivery Excellence a runtime authority.
+
+## Non-goals
+
+- Do not turn Delivery Excellence into an agent runtime.
+- Do not move Policy Fabric gates into this repo.
+- Do not move SocioSphere topology authority into this repo.
+- Do not make dashboards depend on proprietary cloud services.
+- Do not track vanity metrics without evidence.
+- Do not count generated artifacts as complete unless validation and acceptance criteria pass.
+
+## Done criteria for v0.1
+
+- Delivery Excellence has this operating model.
+- delivery-excellence-automation has machine-readable contracts for scoreboards and recent repo activity.
+- SocioSphere references this model as the delivery/performance authority.
+- AgentPlane and Policy Fabric expose enough stable evidence for scoreboard ingestion.
+- At least one cross-estate weekly readout can be generated from repo and evidence signals.
+- At least one customer-safe proof-of-value readout can be generated from an evidence pack.

--- a/docs/reports/agent-harness-absorption-readout-2026-05-05.md
+++ b/docs/reports/agent-harness-absorption-readout-2026-05-05.md
@@ -1,6 +1,6 @@
 # Agent Harness Absorption Readout — 2026-05-05
 
-Status: v0.1 management readout  
+Status: v0.2 management readout  
 Owner plane: Delivery Excellence  
 Scope: cross-estate absorption of Aden/Hive production-agent lessons into SocioProphet, SourceOS, and SociOS-Linux
 
@@ -24,16 +24,16 @@ The key absorption decision is stable:
 
 | Repo | PR | Purpose | Status |
 |---|---:|---|---|
-| `SocioProphet/delivery-excellence` | #9 | Agent harness delivery operating model | Open |
-| `SocioProphet/delivery-excellence-automation` | #7 | Agent harness metric contracts and examples | Open |
+| `SocioProphet/delivery-excellence` | #9 | Agent harness delivery operating model and management readout | Open |
+| `SocioProphet/delivery-excellence-automation` | #7 | Agent harness metric contracts, examples, validator, generator, CI | Open / mergeable |
 | `SocioProphet/sociosphere` | #273 | Cross-estate routing to Delivery Excellence | Open |
-| `SocioProphet/agentplane` | #107 | Runtime contract vocabulary | Open |
-| `SocioProphet/policy-fabric` | #60 | Policy/admission/promotion gate model | Open |
-| `SocioProphet/memory-mesh` | #23 | Memory ledger, artifact pointer, and recall/writeback contract | Open |
-| `SourceOS-Linux/sourceos-spec` | #93 | SourceOS local execution receipt boundary | Open |
-| `SourceOS-Linux/BearBrowser` | #22 | Browser receipt surface | Open |
-| `SourceOS-Linux/TurtleTerm` | #5 | Terminal/operator receipt surface | Open |
-| `SocioProphet/SCOPE-D` | #1 | Agent harness defensive risk-control lanes | Open |
+| `SocioProphet/agentplane` | #107 | Runtime contract vocabulary, schema, example, validator, CI | Open / mergeable |
+| `SocioProphet/policy-fabric` | #60 | Policy/admission/promotion gate model, schema, example, validator | Open |
+| `SocioProphet/memory-mesh` | #23 | Memory ledger, artifact pointer, schema, example, validator, CI | Open / mergeable |
+| `SourceOS-Linux/sourceos-spec` | #93 | SourceOS local execution receipt boundary, schema, example, validator, CI | Open / mergeable |
+| `SourceOS-Linux/BearBrowser` | #22 | Browser receipt surface, schema, example, verifier, CI | Open / mergeable |
+| `SourceOS-Linux/TurtleTerm` | #5 | Terminal/operator receipt surface, schema, example, verifier, CI | Open / mergeable |
+| `SocioProphet/SCOPE-D` | #1 | Agent harness defensive risk-control lanes, schema, example, validator wiring | Open / mergeable |
 
 ## Absorbed lessons
 
@@ -73,42 +73,52 @@ SCOPE-D risk checks become scoreboard inputs: skill risk, MCP risk, browser auto
 
 | Plane | Current score | Status | Rationale |
 |---|---:|---|---|
-| Delivery model | 80 | Green | Operating model PR is open; needs merge and first generated readout. |
-| Metrics automation | 70 | Yellow | Schemas/examples are open; generator still missing. |
-| Topology routing | 75 | Yellow | SocioSphere PR is open; some branches may need update/rebase. |
-| Runtime contracts | 70 | Yellow | AgentPlane vocabulary exists; schemas and emitters remain. |
-| Policy gates | 70 | Yellow | Gate model exists; machine-readable decisions remain. |
-| Memory ledger | 65 | Yellow | Spec exists; schemas/validators and runtime export remain. |
-| SourceOS receipts | 65 | Yellow | Boundary exists; typed schemas and conformance remain. |
-| Browser receipts | 65 | Yellow | Surface exists; policy-enforced examples/verifiers remain. |
-| Terminal receipts | 65 | Yellow | Surface exists; command/mutation examples and verifiers remain. |
-| Defensive validation | 60 | Yellow | Risk-control lanes exist; fixtures and verified reporting extension remain. |
-| Product/customer proof | 45 | Red | Readout contract exists, but live customer-safe projection is not generated yet. |
+| Delivery model | 85 | Green | Operating model and management readout exist; merge still pending. |
+| Metrics automation | 82 | Green | Schemas, examples, validator, generator, and CI workflow are open in PR #7. Live GitHub ingestion remains. |
+| Topology routing | 78 | Yellow | SocioSphere routing PR exists; branch may require update before merge. |
+| Runtime contracts | 80 | Green | AgentPlane now has docs, composite schema, example, validator, and CI. Runtime emitters remain. |
+| Policy gates | 78 | Yellow | Gate model plus first decision schema/example/validator exists; full gate family remains. |
+| Memory ledger | 80 | Green | Memory Mesh now has spec, schema, example, validator, and CI. Runtime export remains. |
+| SourceOS receipts | 80 | Green | SourceOS spec now has receipt boundary, schema, example, validator, and CI. Runtime producers remain. |
+| Browser receipts | 80 | Green | BearBrowser now has receipt surface, schema, example, verifier, and CI. Runtime emission remains. |
+| Terminal receipts | 80 | Green | TurtleTerm now has receipt surface, schema, example, verifier, and CI. Runtime emission remains. |
+| Defensive validation | 78 | Yellow | SCOPE-D now has risk-control docs, schema, example, and validator wiring. More fixtures remain. |
+| Product/customer proof | 62 | Yellow | Customer-proof contract and generator exist; live evidence-pack projection remains. |
 
-Overall absorption baseline: **~68%**.
+Overall absorption baseline: **~79%**.
 
-Interpretation: the estate has absorbed the operating model and plane boundaries. It has not yet completed machine-readable implementation, generators, validators, dashboards, or live metric production.
+Interpretation: the estate has moved from routing/prose absorption to first executable validation across the main planes. It still needs merges, rebases where branches are behind, live emitters, recurring scoreboards, and customer-safe readouts generated from real evidence packs.
+
+## Completed this tranche
+
+1. Added Delivery Excellence metric generator for example activity reports.
+2. Added AgentPlane runtime contract schema, example, validator, and CI workflow.
+3. Added Policy Fabric agent-harness gate-decision schema, example, validator, and Makefile validation wiring.
+4. Added Memory Mesh memory-ledger schema, example, validator, and CI workflow.
+5. Added SourceOS execution-receipt schema, example, validator, and CI workflow.
+6. Added BearBrowser browser-receipt schema, example, verifier, and CI workflow.
+7. Added TurtleTerm terminal-receipt schema, example, verifier, and CI workflow.
+8. Added SCOPE-D agent-harness risk-assessment schema, example, and validator integration.
 
 ## Immediate next tranche
 
-1. Merge or update/rebase the open absorption PRs.
-2. Add generator in `delivery-excellence-automation` for recent repo activity reports from GitHub activity.
-3. Add AgentPlane schemas/examples for `OutcomeSpec`, `GraphSpec`, `SessionEnvelope`, `EvidencePack`, `EvolutionPatch`, and `PromotionGate`.
-4. Add Policy Fabric machine-readable decision schemas for skill, MCP, browser, terminal, memory, judge, human-control, and promotion gates.
-5. Add Memory Mesh schemas/examples and validators for `ArtifactPointer`, `MessageLedgerEvent`, `MemorySnapshot`, and `RecallWritebackEvidence`.
-6. Add SourceOS/BearBrowser/TurtleTerm examples and verifiers for receipt classes.
-7. Add SCOPE-D safe synthetic fixtures for skill, MCP, browser, terminal, memory, graph, and evolution-patch risks.
-8. Generate the first Delivery Excellence scoreboard from real GitHub/repo signals.
+1. Update/rebase branches that are behind current `main`, especially fast-moving SourceOS, BearBrowser, TurtleTerm, SCOPE-D, AgentPlane, and Policy Fabric branches.
+2. Merge or supersede the open absorption PRs.
+3. Replace example-file input in `delivery-excellence-automation` with live GitHub/repo activity ingestion.
+4. Emit AgentPlane `EvidencePack` artifacts using the new runtime contract references.
+5. Emit Memory Mesh artifact pointer and snapshot records from real AgentPlane runs.
+6. Emit BearBrowser and TurtleTerm receipts from actual verifier/smoke paths.
+7. Extend SCOPE-D with additional safe synthetic fixtures for skills, MCP servers, memory poisoning, graph robustness, and evolution-patch risk.
+8. Generate the first recurring Delivery Excellence scoreboard from real repository and evidence signals.
 
 ## Remaining gaps we should not miss
 
-- Live scoreboards are not generated yet.
 - Open PRs are not merged yet.
-- Several branches were reported as behind current `main`; they may need update/rebase before merge.
+- Several branches are behind current `main`; they may need update/rebase before merge.
 - Runtime emitters do not yet produce all new contract objects.
-- Policy gates are still described, not fully enforced for all surfaces.
+- Policy gates are only partially represented by one decision fixture.
 - Skill/MCP registry implementation remains future work.
-- Customer-safe proof-of-value readouts are defined but not generated from evidence packs yet.
+- Customer-safe proof-of-value readouts are generated from example reports, not real evidence packs yet.
 - Dashboard/UI presentation remains future work.
 - Windows/native portability remains a later adoption lane.
 - Billing/usage-ledger hooks remain future work.
@@ -118,10 +128,10 @@ Interpretation: the estate has absorbed the operating model and plane boundaries
 The absorption baseline is complete when:
 
 - all listed PRs are merged or superseded by equivalent merged work;
-- Delivery Excellence can generate at least one cross-estate scoreboard snapshot;
-- AgentPlane can emit or reference the core runtime contract artifacts;
-- Policy Fabric can validate at least one agent-harness gate decision fixture;
-- Memory Mesh can validate at least one artifact pointer / memory snapshot fixture;
-- SourceOS/BearBrowser/TurtleTerm can validate at least one local/browser/terminal receipt fixture;
-- SCOPE-D can validate at least one safe agent-harness risk fixture;
-- a customer-safe proof-of-value readout can be generated from non-sensitive evidence.
+- Delivery Excellence can generate at least one cross-estate scoreboard snapshot from live repo/evidence signals;
+- AgentPlane emits or references the core runtime contract artifacts;
+- Policy Fabric validates representative gate decision fixtures across browser, terminal, memory, skill/MCP, and promotion gates;
+- Memory Mesh validates and emits artifact pointer / memory snapshot fixtures from real runs;
+- SourceOS/BearBrowser/TurtleTerm validate and emit at least one local/browser/terminal receipt fixture from actual smoke paths;
+- SCOPE-D validates safe agent-harness risk fixtures across at least skill, MCP, browser, terminal, memory, and graph lanes;
+- a customer-safe proof-of-value readout is generated from non-sensitive evidence.

--- a/docs/reports/agent-harness-absorption-readout-2026-05-05.md
+++ b/docs/reports/agent-harness-absorption-readout-2026-05-05.md
@@ -1,0 +1,127 @@
+# Agent Harness Absorption Readout — 2026-05-05
+
+Status: v0.1 management readout  
+Owner plane: Delivery Excellence  
+Scope: cross-estate absorption of Aden/Hive production-agent lessons into SocioProphet, SourceOS, and SociOS-Linux
+
+## Executive summary
+
+The Aden/Hive lessons are now routed into the estate as a cross-plane operating model rather than a development-only framework copy.
+
+The key absorption decision is stable:
+
+- Delivery Excellence owns the performance stack: KPI/OKR definitions, scoreboards, work packaging, cadence, proof-of-value, customer-safe readouts, and agent/human collaboration metrics.
+- SocioSphere owns topology and routing, but does not duplicate scoreboards.
+- AgentPlane owns runtime execution, run/session evidence, replay, failure diagnosis, evolution patches, and promotion artifacts.
+- Policy Fabric / Guardrail Fabric own admission, grants, guardrails, judges, human-control gates, and promotion gates.
+- Memory Mesh owns artifact pointers, message-native ledgers, memory snapshots, recall/writeback evidence, and safe metric projections.
+- SourceOS owns local execution receipt boundaries across local runtime, shell, browser, model carry, host mutation, and downloads.
+- BearBrowser owns governed browser receipts and credential/browser action evidence.
+- TurtleTerm owns governed terminal receipts and operator approval evidence.
+- SCOPE-D owns defensive validation for skills, MCP servers, browser actions, terminal actions, memory flows, graph robustness, and evolution patches.
+
+## Open absorption PRs
+
+| Repo | PR | Purpose | Status |
+|---|---:|---|---|
+| `SocioProphet/delivery-excellence` | #9 | Agent harness delivery operating model | Open |
+| `SocioProphet/delivery-excellence-automation` | #7 | Agent harness metric contracts and examples | Open |
+| `SocioProphet/sociosphere` | #273 | Cross-estate routing to Delivery Excellence | Open |
+| `SocioProphet/agentplane` | #107 | Runtime contract vocabulary | Open |
+| `SocioProphet/policy-fabric` | #60 | Policy/admission/promotion gate model | Open |
+| `SocioProphet/memory-mesh` | #23 | Memory ledger, artifact pointer, and recall/writeback contract | Open |
+| `SourceOS-Linux/sourceos-spec` | #93 | SourceOS local execution receipt boundary | Open |
+| `SourceOS-Linux/BearBrowser` | #22 | Browser receipt surface | Open |
+| `SourceOS-Linux/TurtleTerm` | #5 | Terminal/operator receipt surface | Open |
+| `SocioProphet/SCOPE-D` | #1 | Agent harness defensive risk-control lanes | Open |
+
+## Absorbed lessons
+
+### Outcome-first operating model
+
+The unit of management is no longer a task alone. It is an outcome with measurable value, success criteria, risk tier, evidence requirements, policy gates, execution plan, proof artifacts, and review cadence.
+
+### Graph-first visibility
+
+Generated plan graphs and executable graphs become operational visibility artifacts. They support plan review, approval gates, failure-path reasoning, dependency mapping, and Delivery Excellence scoreboards.
+
+### Evidence over logs
+
+Logs are diagnostic, not sufficient proof. The estate now routes toward validated evidence packs, receipt artifacts, replay pointers, policy decisions, human-control events, and artifact hashes.
+
+### Human control as measurable data
+
+Approvals, rejections, overrides, clarifications, risk acceptances, credential grants, scope changes, and promotion approvals are typed control events. They become governance evidence and Delivery Excellence metrics.
+
+### Skills and MCP servers as governed assets
+
+Skills, MCP servers, tool packs, and templates are not incidental helper files. They are capability assets with trust tiers, tests, grants, risk scores, install/readiness state, and deprecation/revocation paths.
+
+### Browser and terminal surfaces as production evidence sources
+
+BearBrowser and TurtleTerm now have explicit receipt responsibilities. Browser and terminal work are not opaque side effects; they produce evidence for AgentPlane, Policy Fabric, Memory Mesh, SCOPE-D, and Delivery Excellence.
+
+### Local-first execution receipts
+
+SourceOS receipt boundaries make local runtime, shell, browser, model carry, host mutation, credential use, downloads, offline posture, and replay eligibility measurable and auditable.
+
+### Defensive validation as delivery metric
+
+SCOPE-D risk checks become scoreboard inputs: skill risk, MCP risk, browser automation risk, terminal action risk, memory risk, graph robustness, evolution-patch risk, blocked promotion count, verified-run count, and control coverage.
+
+## Current coverage scorecard
+
+| Plane | Current score | Status | Rationale |
+|---|---:|---|---|
+| Delivery model | 80 | Green | Operating model PR is open; needs merge and first generated readout. |
+| Metrics automation | 70 | Yellow | Schemas/examples are open; generator still missing. |
+| Topology routing | 75 | Yellow | SocioSphere PR is open; some branches may need update/rebase. |
+| Runtime contracts | 70 | Yellow | AgentPlane vocabulary exists; schemas and emitters remain. |
+| Policy gates | 70 | Yellow | Gate model exists; machine-readable decisions remain. |
+| Memory ledger | 65 | Yellow | Spec exists; schemas/validators and runtime export remain. |
+| SourceOS receipts | 65 | Yellow | Boundary exists; typed schemas and conformance remain. |
+| Browser receipts | 65 | Yellow | Surface exists; policy-enforced examples/verifiers remain. |
+| Terminal receipts | 65 | Yellow | Surface exists; command/mutation examples and verifiers remain. |
+| Defensive validation | 60 | Yellow | Risk-control lanes exist; fixtures and verified reporting extension remain. |
+| Product/customer proof | 45 | Red | Readout contract exists, but live customer-safe projection is not generated yet. |
+
+Overall absorption baseline: **~68%**.
+
+Interpretation: the estate has absorbed the operating model and plane boundaries. It has not yet completed machine-readable implementation, generators, validators, dashboards, or live metric production.
+
+## Immediate next tranche
+
+1. Merge or update/rebase the open absorption PRs.
+2. Add generator in `delivery-excellence-automation` for recent repo activity reports from GitHub activity.
+3. Add AgentPlane schemas/examples for `OutcomeSpec`, `GraphSpec`, `SessionEnvelope`, `EvidencePack`, `EvolutionPatch`, and `PromotionGate`.
+4. Add Policy Fabric machine-readable decision schemas for skill, MCP, browser, terminal, memory, judge, human-control, and promotion gates.
+5. Add Memory Mesh schemas/examples and validators for `ArtifactPointer`, `MessageLedgerEvent`, `MemorySnapshot`, and `RecallWritebackEvidence`.
+6. Add SourceOS/BearBrowser/TurtleTerm examples and verifiers for receipt classes.
+7. Add SCOPE-D safe synthetic fixtures for skill, MCP, browser, terminal, memory, graph, and evolution-patch risks.
+8. Generate the first Delivery Excellence scoreboard from real GitHub/repo signals.
+
+## Remaining gaps we should not miss
+
+- Live scoreboards are not generated yet.
+- Open PRs are not merged yet.
+- Several branches were reported as behind current `main`; they may need update/rebase before merge.
+- Runtime emitters do not yet produce all new contract objects.
+- Policy gates are still described, not fully enforced for all surfaces.
+- Skill/MCP registry implementation remains future work.
+- Customer-safe proof-of-value readouts are defined but not generated from evidence packs yet.
+- Dashboard/UI presentation remains future work.
+- Windows/native portability remains a later adoption lane.
+- Billing/usage-ledger hooks remain future work.
+
+## Done criteria for absorption baseline
+
+The absorption baseline is complete when:
+
+- all listed PRs are merged or superseded by equivalent merged work;
+- Delivery Excellence can generate at least one cross-estate scoreboard snapshot;
+- AgentPlane can emit or reference the core runtime contract artifacts;
+- Policy Fabric can validate at least one agent-harness gate decision fixture;
+- Memory Mesh can validate at least one artifact pointer / memory snapshot fixture;
+- SourceOS/BearBrowser/TurtleTerm can validate at least one local/browser/terminal receipt fixture;
+- SCOPE-D can validate at least one safe agent-harness risk fixture;
+- a customer-safe proof-of-value readout can be generated from non-sensitive evidence.


### PR DESCRIPTION
## Summary

Adds the Delivery Excellence operating model for the Aden/Hive-derived agent harness lessons across the full estate.

This keeps Delivery Excellence in its lane as the performance, metering, KPI/OKR, scoreboarding, operating cadence, work packaging, and proof-of-value authority while leaving runtime execution to AgentPlane, policy gates to Policy Fabric/Guardrail Fabric, topology to SocioSphere, and implementation to the appropriate product/runtime repos.

## Scope

- Adds `docs/agent-harness-delivery-operating-model.md`.
- Links the model from the root README.
- Covers outcome-first delivery, graph-first operating visibility, human-control accounting, cost/failure signals, skill/MCP asset scoring, customer proof, cross-estate signal producers, and initial scoreboards.
- Includes a recent active repo watchlist so the model is not limited to the April 29 dossier baseline.

## Validation

Docs-only change. No runtime behavior changed.

## Follow-up

Next PR should land machine-readable contracts in `SocioProphet/delivery-excellence-automation` for recent repo activity, delivery metric events, scoreboard snapshots, customer-proof readouts, human-control events, and skill/MCP asset scores.