### PR TITLE
docs: add Delivery Excellence mainline audit

### DIFF
--- a/docs/delivery-excellence-mainline-audit.md
+++ b/docs/delivery-excellence-mainline-audit.md
@@ -1,0 +1,117 @@
+# Delivery Excellence Mainline Audit
+
+## Purpose
+
+This audit records the current Delivery Excellence repo-family state after the CoC/KMASS/metadata contract work and the newer Professional Intelligence delivery-control work both landed.
+
+## Repo family
+
+The active Delivery Excellence topology remains:
+
+1. `delivery-excellence` — human-readable canon, control register, service model, and guidance
+2. `delivery-excellence-automation` — machine-readable schemas, examples, and validators
+3. `delivery-excellence-boards` — portfolio, roadmap, and board projection
+4. `delivery-excellence-innersource` — reusable asset readiness, contribution, and maintainer model
+5. `delivery-excellence-bounties` — incentive and payout layer downstream of evidence and gates
+
+## Current mainline state
+
+### `delivery-excellence`
+Current mainline includes:
+- agentic services operating model
+- action classes and autonomy gates
+- phase gates, RACI, and KPI structure
+- shared object model
+- GTM, contracting, and customer-success model
+- incentive and payout objects
+- KMASS metrics v1
+- metadata operations CoC model
+- metadata SLA and escalation model
+- CoC service catalog and KPI mapping
+- Professional Intelligence control register
+
+### `delivery-excellence-automation`
+Current mainline includes:
+- DelEx governance automation scaffold
+- agentic service contract schemas and examples
+- engagement, gate, action, dependency, exception, reusable asset, and customer-success review objects
+- payout and escrow objects
+- bounty program policy object
+- KMASS metric and metadata operations objects
+- service catalog and SLA objects
+- Professional Intelligence contracts, examples, and validation
+
+### `delivery-excellence-boards`
+Current mainline includes:
+- board consumption index
+- portfolio object model
+- gate and board field mapping
+- service delivery projection
+- Professional Intelligence board lanes are tracked as an open follow-up item
+
+### `delivery-excellence-innersource`
+Current mainline includes:
+- InnerSource consumption index
+- service contribution model
+- repo readiness standard
+- maintainer role map
+- Professional Intelligence playbook/readiness work landed in the related wave
+
+### `delivery-excellence-bounties`
+Current mainline includes:
+- bounties consumption index
+- evidence scoring alignment
+- payout gates from delivery gates
+- incentive boundary rules
+- customer-success/support worked example
+
+## Open issue clusters
+
+### Automation enforcement
+- expand the group ledger
+- create GitHub teams
+- tighten CODEOWNERS and branch protections
+
+### Boards and program visibility
+- choose open-source Aha-style stack
+- define execution environment baseline
+- add Professional Intelligence program board lanes and rollup model
+
+### InnerSource hardening
+- implement repo readiness linter and CI
+- connect roles to RBAC and readiness standards
+
+### Bounties hardening
+- deterministic scoring function
+- escrow/payout gating policy and automation contract
+
+## Current Professional Intelligence status
+
+The Professional Intelligence control register reports:
+- overall alignment: 42%
+- demo readiness: 34%
+- Gate 1 complete
+- Gate 2 complete
+- Gate 3 active
+- Gate 4 not yet runnable end-to-end
+
+Active Gate 3 dependencies include:
+- Agentplane workflow bundle
+- Agent Registry tool grants
+- Memory Mesh context pack
+- Sherlock search packet
+- Prophet Core Query context contract
+- Model Router policy examples
+- Guardrail Fabric pack
+
+## Interpretation
+
+Delivery Excellence is no longer only a consulting-method repo family. It is now functioning as a cross-repo governance and delivery-control substrate for governed agentic services, CoC operations, metadata quality, measurement contracts, Professional Intelligence program delivery, incentives, and reusable assets.
+
+## Immediate consolidation priorities
+
+1. Add a single automation validation-suite runner so all contract validators can be executed consistently.
+2. Resolve the automation enforcement issues around group ledger, CODEOWNERS, and branch protection.
+3. Implement the Professional Intelligence program board lanes in `delivery-excellence-boards`.
+4. Implement InnerSource readiness linting.
+5. Decide whether bounties needs additional machine-readable scoring schemas beyond the current payout and policy objects.


### PR DESCRIPTION
## Summary

Add a current-state mainline audit for the full Delivery Excellence repo family.

## Adds

- `docs/delivery-excellence-mainline-audit.md`

## Why

The Delivery Excellence estate has moved beyond the original CoC/KMASS/metadata work. The canon now also carries a Professional Intelligence control register and delivery-control substrate. This audit captures the current topology, merged mainline state, open issue clusters, Professional Intelligence gate status, and immediate consolidation priorities.

## Notes

This is a canon-side coordination artifact. It does not alter schemas or CI. The companion automation cleanup is staged separately in `delivery-excellence-automation`.
