### PR TITLE
Add Gate 4 status addendum

### DIFF
--- a/docs/professional-intelligence-gate4-status.md
+++ b/docs/professional-intelligence-gate4-status.md
@@ -1,0 +1,76 @@
+# Professional Intelligence OS Gate 4 Status
+
+## Status date
+
+2026-05-05
+
+## Current completion readout
+
+- Overall alignment: 68%
+- Architecture spine: 42%
+- DelEx governance: 48%
+- DelEx automation: 45%
+- Platform contracts: 50%
+- Governed execution substrate: 65%
+- Evidence Plane: 55%
+- Workspace, search, and query surface: 45%
+- UI and dashboard integration: 38%
+- Sociosphere topology integration: 40%
+- Policy Fabric integration: 45%
+- ContractForge / Obligation Ledger integration: 45%
+- Institution Context Engine: 55%
+- Governance loops: 52%
+- Cybernetic controls: 50%
+- Playbooks: 35%
+- Runtime implementation: 42%
+- Demo readiness: 70%
+
+## Material change since prior register
+
+`SocioProphet/prophet-platform#424` is merged. The platform now has a validated Gate 4 orchestration artifact that binds the previously merged Professional Intelligence pieces into one traceable demo control object.
+
+The orchestration object ties together:
+
+- playbook reference;
+- workroom reference;
+- context query reference;
+- context pack reference;
+- search packet reference;
+- policy decision references;
+- obligation references;
+- model routing references;
+- runtime control references;
+- Agent Registry authority references;
+- Agentplane run references;
+- Model Governance Ledger references;
+- evidence references;
+- adoption event references.
+
+## Gate status
+
+Gate 1: complete.
+
+Gate 2: complete.
+
+Gate 3: complete as a recordable slice.
+
+Gate 4: active. The platform orchestration object is merged, but the demo still needs a local runner or runbook that executes or verifies the sequence end to end.
+
+## Next control move
+
+Create the first local Gate 4 runner/runbook in `SocioProphet/prophet-platform`.
+
+Required runner behavior:
+
+1. Load the Gate 4 orchestration example.
+2. Verify required references exist in the orchestration object.
+3. Emit a demo verification report.
+4. Emit or validate an adoption event reference.
+5. Emit or validate evidence references.
+6. Provide a single command suitable for DelEx demo acceptance.
+
+## Remaining work orders
+
+- `SocioProphet/delivery-excellence-boards#5`: program board lanes and rollup.
+- `SocioProphet/global-devsecops-intelligence#10`: governance and control-plane assessment.
+- New required work: `SocioProphet/prophet-platform` Gate 4 runner/runbook.


### PR DESCRIPTION
## Summary

Adds `docs/professional-intelligence-gate4-status.md`.

This records the current Professional Intelligence OS Gate 4 state and the next platform runner/runbook action.

## Validation

Docs-only update.