### PR TITLE
KMASS: first measured baseline, and enforcement for the contract's own gate rule

### DIFF
--- a/.github/workflows/validate-contracts.yml
+++ b/.github/workflows/validate-contracts.yml
@@ -1,0 +1,37 @@
+name: validate-contracts
+
+# This repo had no CI at all before 2026-08-01, which meant its validators --
+# including the KMASS scoreboard gate that enforces the contract's own
+# "no phase complete without evidence" rule -- were advisory scripts nobody ran.
+# A governance repo whose own contracts are unenforced is the failure mode it
+# exists to prevent, so all validators run here, not just the new one.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: KMASS scoreboard gate
+        run: python3 tools/validate_kmass_scoreboard.py
+
+      - name: OrgGov scorecard contract
+        run: python3 tools/validate_orggov_scorecard.py
+
+      - name: Computational artifact scoreboard contract
+        run: python3 tools/validate_computational_artifact_scoreboard.py
+
+      - name: IOES delivery outcome record contract
+        run: python3 tools/validate_ioes_delivery_outcome_record.py

--- a/docs/design/org-digital-twin-v0.md
+++ b/docs/design/org-digital-twin-v0.md
@@ -1,0 +1,71 @@
+# Org Digital Twin v0 — the SYS.SCALE instrument
+
+**Status:** design, not built
+**Unblocks:** `SYS.SCALE.TBD` in [`docs/kmass-metrics-v1.md`](../kmass-metrics-v1.md)
+**Work order:** [`WO-KMASS-01.09`](../work-orders/WO-KMASS-01-close-the-baseline.md)
+
+## Why this is not a side quest
+
+`SYS.SCALE.TBD` is the only row in the metric contract whose phase targets are `TBD / TBD / TBD`. That is usually a sign a metric was hard to specify. Read its variables, though, and the reason is clearer — they are not product measurements at all:
+
+> `|K|` knowledge elements · `|E|` relations or provenance edges · `|P(task)|` policies per task · `|CoP|` communities of practice and role distributions · task throughput by role and CoP
+
+Every one of those describes **the organization**, not the software. There is no way to fill this row by instrumenting a service. It requires a model of the org itself: what it knows, who does what, which policies bind which tasks, and how work actually flows between roles.
+
+That model is the digital twin. So the twin isn't an adjacent ambition to bolt on after the metrics work — it is the missing instrument for the one metric the contract couldn't specify. Building it closes the last row and, in the same move, gives you the thing you actually want: a substrate to run scenarios against before committing roadmap decisions.
+
+## What the twin has to be to be useful
+
+A digital twin that is merely a diagram of the org is a wall poster. To be an instrument it has to satisfy three properties, in increasing order of difficulty:
+
+**1. It is derived, not authored.** If the twin is hand-maintained it will drift from reality within a quarter and quietly become fiction — the same failure as a hand-maintained architecture diagram, and the same failure the estate already has a name for. Its nodes and edges must be *extracted* from systems that are already load-bearing: repos and their manifests, `workspace-inventory`'s `repos.yaml` authority roles, `agent-registry` identities and grants, `policy-fabric` policy bindings, `ontogenesis` semantics, CI run history, PR and review flow. A fact that has no upstream system to derive it from does not belong in the twin.
+
+**2. It is measured against the same gate as everything else.** The twin emits a `SYS.SCALE` value into a KMASS scoreboard and is subject to `validate_kmass_scoreboard.py` like any other metric. If the twin cannot produce evidence artifacts and a reproducible run log, it doesn't get to make a claim. No exemption for the instrument.
+
+**3. It is counterfactual.** A twin you can only read is a dashboard. The point is to ask *what if* — and get a defensible answer. That is the third property and the hardest, so it comes last, not first.
+
+## Layering
+
+Build in this order. Each layer is independently useful, which matters because the estate's characteristic failure is large designs that never reach enforcement.
+
+### Layer 1 — Inventory graph (derived, static)
+
+Nodes: repos, services, capabilities, policies, contracts, roles, agents.
+Edges: `provides`, `consumes`, `governed_by`, `owned_by`, `depends_on`.
+
+Almost all of this already exists in fragments. `workspace-inventory/inventory/repos.yaml` is the strongest seed — it already carries `authority_role`, `provides`, `consumes`, `consumed_by`, `adoption_state`, `validation_state`, and `drift_risk` per repo. That file is a partial org twin that nobody has called one.
+
+Yields immediately: `|K|` (knowledge elements) and `|E|` (provenance/relation edges) — the first two `SYS.SCALE` variables, from data that exists today.
+
+### Layer 2 — Work and policy overlay (derived, dynamic)
+
+Overlay onto Layer 1: tasks in flight, which policies bind which task types, which roles are permitted which actions, throughput and cycle time per role.
+
+Sources: `delivery-excellence` work-item schemas and boards, `policy-fabric` bindings, `agent-registry` grants, CI/PR history for real throughput rather than declared throughput.
+
+Yields: `|P(task)|`, `|CoP|`, role distributions, task throughput by role — completing the `SYS.SCALE` variable set.
+
+**This is the point at which the row can be filled and phase targets can finally be set with real numbers instead of TBD.** Targets set from a measured baseline are defensible; targets set from imagination are the thing that produced TBD in the first place.
+
+### Layer 3 — Scenario engine (counterfactual)
+
+Only now does simulation make sense, because only now is there a calibrated model to perturb.
+
+Questions worth being able to answer:
+
+- *If the corpus reaches 20k documents, where does the first bottleneck appear — retrieval latency, policy evaluation, or human review throughput?*
+- *If a CoP doubles in size, which policies become the constraint?*
+- *If we descope video (WO-01.08), what does the achievable Phase-2 envelope look like?*
+- *Which single unblocking action moves the most `UNMEASURED` rows to `MEASURED`?* — the twin should be able to re-derive the work order's own dependency ordering, and if it disagrees with the hand-written ordering, that disagreement is information.
+
+Existing substrate worth reusing rather than rebuilding: `hellgraph` (typed atoms, append-only valuations, deterministic replay) is a good fit for a twin that must be re-runnable and auditable. `meshrush` and `cairnpath-mesh` already describe graph-native traversal over a hypergraph world model. The GBRG blast-radius work is essentially scenario propagation over a dependency graph — the same shape as "what breaks if X changes."
+
+## Honest constraints
+
+- **Layer 3 is not near-term.** Layers 1 and 2 are extraction and aggregation over data that mostly exists. Layer 3 requires a calibrated model, and calibration requires the measured baselines that WO-KMASS-01 is producing. Attempting simulation before the baseline exists produces confident, wrong answers — strictly worse than no answers.
+- **A twin derived from declarations inherits their inaccuracy.** `workspace-inventory` records `adoption_state: partial` and `validation_state: unknown` across many entries, and today's baseline found several services whose declared state and measured state diverged sharply. The twin must distinguish *declared* from *verified* edges and render them differently. An edge that has never been probed is a hypothesis, not a fact — the same discipline the scoreboard applies with `MEASURED` vs `UNMEASURED`.
+- **Scope the twin to what has an upstream source.** The temptation is to model the org as you wish it were. Every node must trace to a system of record, or it is decoration.
+
+## First concrete step
+
+Build Layer 1 as a read-only extractor that emits a graph from `workspace-inventory/repos.yaml` plus live `gh` repo metadata, and report `|K|` and `|E|` into a `SYS.SCALE` row. Small, entirely derived from existing sources, and it converts the contract's only TBD row into a partial measurement — which is what earns the right to build Layer 2.

--- a/docs/reports/kmass-baseline-readout-2026-08-01.md
+++ b/docs/reports/kmass-baseline-readout-2026-08-01.md
@@ -70,7 +70,7 @@ p50 of **8.8ms** against a Phase-3 target of 1 second. Recorded as `vacuousPass:
 
 This is the most dangerous number in the scoreboard — it is the one that would survive a slide review unchallenged. The schema and validator exist specifically so it cannot be promoted into a phase claim.
 
-**Also worth stating plainly:** `search_query_total` was exactly `0` before this run. The 30 queries in this readout were the first ever served by the production search-orchestrator. Green health checks had been reporting success on a path no traffic had ever traversed — the same shape as the Loki incident earlier the same day, where a merged, healthy-looking pipeline had ingested zero bytes for 2.5 days.
+**Also worth stating plainly, precisely:** `search_query_total` was exactly `0` before this run. The counter is process-local (`mode: in-memory`, like everything else in this tier), and the current pod was 3d2h old with 0 restarts — so this proves at least 3 days with no evidence of query traffic, not that the service has literally never served a query since the Deployment was created (2026-07-13, ~3 weeks earlier); an earlier pod incarnation could have. Either reading lands the same place: green health checks were reporting success on a path with no confirmed traffic for at least three days — the same shape as the Loki incident earlier the same day, where a merged, healthy-looking pipeline had ingested zero bytes for 2.5 days.
 
 ## Run log
 

--- a/docs/reports/kmass-baseline-readout-2026-08-01.md
+++ b/docs/reports/kmass-baseline-readout-2026-08-01.md
@@ -1,0 +1,108 @@
+# KMASS Baseline Readout — 2026-08-01
+
+First measured instance of the metric contract in [`docs/kmass-metrics-v1.md`](../kmass-metrics-v1.md).
+
+That contract has existed with 10 fully-specified metrics — ids, units, phase targets, measurement protocols, sample-size rules, required evidence artifacts — and a closing Gate implication rule. Prior to this run, **none of its metric ids appeared anywhere else in the repository.** Zero measurements had ever been taken, so the gate rule it declares for itself had never once fired.
+
+Scoreboard: [`scoreboards/kmass-baseline-2026-08-01.json`](../../scoreboards/kmass-baseline-2026-08-01.json)
+Validator: `python3 tools/validate_kmass_scoreboard.py`
+
+## Headline
+
+| | |
+|---|---|
+| Metrics in contract | 10 |
+| Measured | **2** |
+| Of those, vacuous (meets target but means nothing) | **1** |
+| Unmeasured (capability exists, no valid run) | 5 |
+| Unbuilt (capability does not exist) | 3 |
+| Legitimate phase claims earned | **0** |
+
+Retrievable documents: **12** against a Phase-1 target of 20,000 — 0.06%.
+
+## What is actually working
+
+Two components are load-bearing and real:
+
+- **`embeddings`** — serving `nomic-ai/nomic-embed-text-v1.5` at 768 dimensions, p50 103ms over 10 samples. Healthy.
+- **`sherlock-engine`** — tantivy index, p50 6.9ms, returned non-empty results for 14 of 30 queries against its 12 documents. Small, but genuine retrieval.
+
+Everything below is built on the assumption that these two are the foundation to extend, not replace.
+
+## The four findings that matter
+
+### 1. The retrieval tier cannot accumulate a corpus — architectural, not volumetric
+
+Zero PersistentVolumeClaims back any retrieval service.
+
+| Service | Storage | Contents |
+|---|---|---|
+| `sherlock-engine` | `emptyDir`, 256Mi cap | 12 docs |
+| `commons-search` | `store: memory` | 0 |
+| `memoryd` | `backend: memory` | 0 resources / 0 events / 0 memories |
+| `search-orchestrator` | `mode: in-memory` | 1421 seeded, **not retrievable** |
+
+Every pod restart resets the corpus to zero. The 20k → 120k → 800k growth curve is unreachable by construction. No amount of ingestion effort fixes this before durable storage exists.
+
+### 2. `search-orchestrator` returns zero results for every query
+
+30 diverse queries returned `results: []`. So did generic probes — `a`, `the`, `learning`, `course`, `academy`, `*`, and the empty string — across every mode tried (`default`, `semantic`, `keyword`, `hybrid`, `all`).
+
+Its own counters confirm this is not a client-side parsing artifact: `search_query_total` advanced 0 → 30 while `academy_result_total` stayed at **0**. The 1421 seeded academy records are not connected to the retrieval path.
+
+### 3. The search policy gate has never fired — including during this run
+
+Before the run and after 30 successful queries, all five policy counters read zero:
+
+```
+policy_decision_allow_total    0 -> 0
+policy_decision_deny_total     0 -> 0
+policy_decision_local_total    0 -> 0
+policy_decision_remote_total   0 -> 0
+policy_decision_fallback_total 0 -> 0
+```
+
+A policy gate that does not evaluate on the request path is declared, not enforced. Whether it is short-circuited by the empty result set or simply unwired, the conclusion for a reviewer is identical: there is no evidence this control has ever made a decision.
+
+### 4. Latency "passes" Phase 3 by 113x, and the pass is worthless
+
+p50 of **8.8ms** against a Phase-3 target of 1 second. Recorded as `vacuousPass: true` and claiming no phase, because all 30 queries returned nothing. Measuring the latency of returning an empty set measures nothing.
+
+This is the most dangerous number in the scoreboard — it is the one that would survive a slide review unchallenged. The schema and validator exist specifically so it cannot be promoted into a phase claim.
+
+**Also worth stating plainly:** `search_query_total` was exactly `0` before this run. The 30 queries in this readout were the first ever served by the production search-orchestrator. Green health checks had been reporting success on a path no traffic had ever traversed — the same shape as the Loki incident earlier the same day, where a merged, healthy-looking pipeline had ingested zero bytes for 2.5 days.
+
+## Run log
+
+Probes ran **inside the cluster** from a pod in the `socioprophet` namespace, against ClusterIP service DNS, to exclude ingress and WAN variance from the latency figures. Python stdlib `urllib` only; latency captured with `time.perf_counter()` around the full request/response cycle.
+
+Environment: `gke_socioprophet-platform_us-central1_prophet-platform`
+
+Query set: 30 fixed domain-relevant strings (`governance policy`, `evidence receipt`, `agent registry`, … `scoreboard metric`), meeting the contract's minimum of 30 queries per phase per modality.
+
+Sequence:
+
+1. Read `/healthz` on `memoryd`, `commons-search`, `search-gateway`, `search-orchestrator`, `holmes`, `sherlock-engine`, `embeddings` — captured store backends and document counts.
+2. Read `/v1/search/debug/config` and `/v1/search/debug/metrics` on `search-orchestrator` — captured pre-run counters.
+3. Issued 30 `POST /v0/search/query` with the correct `SearchRequest` shape (`query_id`, `actor_id`, `text`, `mode`, `limit`), timing each.
+4. Issued 30 `GET /search?q=` against `sherlock-engine`, timing each.
+5. Issued 10 `POST /v1/embeddings`, timing each.
+6. Re-read `/v1/search/debug/metrics` — computed the counter delta.
+7. Fairness pass: re-queried with generic terms and all five modes to rule out vocabulary mismatch as the cause of zero results.
+8. Checked cluster-wide for video/media/ASR pods and for PVCs backing any retrieval service.
+
+An earlier attempt used `{"query": ...}` and got HTTP 422 across the board. That was a wrong payload shape on my side, not a service fault; the schema was read from `/openapi.json` and the run repeated correctly. Recorded here so the 422s in any captured logs are not mistaken for a defect.
+
+No secrets, file paths, actor identities, or query contents are persisted in the scoreboard's evidence strings.
+
+## Reproducing
+
+```bash
+python3 tools/validate_kmass_scoreboard.py
+```
+
+The validator is fail-closed and was proven to fire in both directions before being committed. Five adversarial mutations of this scoreboard were each caught: claiming a phase off the vacuous latency pass, deleting an inconvenient metric row, claiming a phase with no run log or evidence, marking a metric measured with a null value, and leaving a gap unexplained.
+
+## What this readout is for
+
+The `UNMEASURED` and `UNBUILT` rows are not gaps in the report. They **are** the program backlog, derived from measurement rather than invented in a planning session. They are worked in [`docs/work-orders/WO-KMASS-01-close-the-baseline.md`](../work-orders/WO-KMASS-01-close-the-baseline.md).

--- a/docs/work-orders/WO-KMASS-01-close-the-baseline.md
+++ b/docs/work-orders/WO-KMASS-01-close-the-baseline.md
@@ -1,0 +1,198 @@
+# WO-KMASS-01 — Close the Baseline
+
+**Origin:** [`docs/reports/kmass-baseline-readout-2026-08-01.md`](../reports/kmass-baseline-readout-2026-08-01.md)
+**Contract:** [`docs/kmass-metrics-v1.md`](../kmass-metrics-v1.md)
+**Status:** open
+**Objective:** move every metric in the contract from `UNBUILT`/`UNMEASURED` to `MEASURED`, and earn the first legitimate Phase-1 claim.
+
+This work order is derived from measurement, not planning. Every task below exists because a specific metric could not be measured on 2026-08-01, and each carries the metric id it unblocks.
+
+## Dependency shape
+
+Most of the backlog is blocked behind two root causes, not ten independent gaps:
+
+```
+  WO-01  durable retrieval tier ──┬── WO-02 reconnect orchestrator retrieval
+                                  │        └── WO-03 policy gate on the request path
+                                  │        └── WO-04 labeled eval set ── WO-05 non-vacuous latency/actions
+                                  └── WO-06 corpus ingestion to 20k
+  WO-07  capture instrumentation (independent)
+  WO-08  media/ASR tier (independent, largest)
+  WO-09  org twin ── unblocks SYS.SCALE (see design note)
+  WO-10  wire the gate into CI (independent, do first — it is cheap)
+```
+
+Sequencing consequence: **WO-01 gates six other items.** Nothing in TA B or TA D can produce a durable number until storage is durable. Do not parallelise the dependents ahead of it.
+
+---
+
+## WO-KMASS-01.10 — Wire the scoreboard gate into CI
+
+**Unblocks:** the enforcement of every row below
+**Effort:** hours
+**Owner repo:** `delivery-excellence`
+
+`tools/validate_kmass_scoreboard.py` exists and is proven fail-closed in both directions, but nothing runs it automatically yet. Until it is a required check, the gate rule remains advisory — the exact condition this program is trying to cure.
+
+**Acceptance:**
+- [ ] `.github/workflows/kmass-scoreboard.yml` runs the validator on every PR touching `scoreboards/**`, `schemas/kmass-scoreboard.*`, or `docs/kmass-metrics-v1.md`
+- [ ] The check is marked **required** in branch protection, matching the `gate / check` pattern already required across six estate repos
+- [ ] Adding a new metric id to the contract makes existing scoreboards fail until measured (already implemented — verify it in CI, don't assume)
+
+**Do this first.** It is the cheapest item and it makes every later claim falsifiable.
+
+---
+
+## WO-KMASS-01.01 — Give the retrieval tier durable storage
+
+**Unblocks:** `TAB.TEXT.SCALE`, and transitively `TAB.TEXT.GRAN`, `TAD.RELEVANCE.JFM`, `TAD.ACTIONS.JE`, `SYS.SPEEDUP`
+**Effort:** days
+**Owner repo:** `prophet-platform` (`infra/k8s/`)
+**Severity:** critical — this is the single highest-leverage item in the work order
+
+Every store in the retrieval tier is non-durable: `sherlock-engine` on a 256Mi `emptyDir`, `commons-search` and `memoryd` on in-memory backends, `search-orchestrator`'s academy repository in-memory with no configured file or carrier source. Corpus resets to zero on every pod restart.
+
+**Acceptance:**
+- [ ] `sherlock-engine`'s tantivy index is on a PVC sized for the Phase-2 target (120k docs), not an `emptyDir`
+- [ ] `memoryd` runs against a persistent backend (Qdrant is already the documented intent) rather than `backend: memory`
+- [ ] `commons-search` either gets a durable store or is explicitly retired as duplicative of `sherlock-engine` — decide, don't leave two empty in-memory indices
+- [ ] **Proof of durability:** delete each pod, confirm document count survives. A green `/healthz` is not evidence; the count after a restart is.
+- [ ] Note the GKE Autopilot constraint learned this week: write-mode `hostPath` is rejected outright by the Warden admission webhook. Use PVCs.
+
+---
+
+## WO-KMASS-01.02 — Reconnect the orchestrator's retrieval path
+
+**Unblocks:** `TAB.TEXT.GRAN`, `TAD.RELEVANCE.JFM`, and de-vacuums `TAD.LATENCY.JIT`
+**Effort:** days
+**Owner repo:** `prophet-platform` (`apps/search-orchestrator`)
+**Severity:** critical
+
+`search-orchestrator` holds 1421 seeded academy records and returns `results: []` for every query in every mode, including wildcard and empty string. `academy_result_total` stayed at 0 across 30 successful queries. The seeded corpus is not wired to the query path.
+
+**Acceptance:**
+- [ ] A query matching known seeded content returns a non-empty result set
+- [ ] `academy_result_total` advances when results are returned
+- [ ] `academy_ingest_total` advances when content is ingested (currently permanently 0 — ingestion has never run)
+- [ ] One of `json_file` / `lampstand_jsonl` / `lampstand_carrier` is configured `true` in `/v1/search/debug/config`, so the corpus has a real source rather than a seed
+- [ ] **Regression test:** a test that fails if any query path returns the empty set for a term known to be in the corpus. This defect was invisible because nothing asserted non-emptiness.
+
+---
+
+## WO-KMASS-01.03 — Put the policy gate on the request path
+
+**Unblocks:** credible TA D governance claims; no metric directly, which is exactly why it has gone unnoticed
+**Effort:** days
+**Owner repo:** `prophet-platform` + `policy-fabric`
+**Severity:** critical
+
+All five `policy_decision_*` counters read zero before and after 30 real queries. `policy_fabric_endpoint` is `false`; the service runs in `local-fallback` mode and even the fallback counter never increments.
+
+**Acceptance:**
+- [ ] A query produces a non-zero increment on exactly one of `allow` / `deny` counters
+- [ ] `policy_fabric_endpoint` is configured, and `remote` vs `local` vs `fallback` counters distinguish which path served the decision
+- [ ] **Prove teeth both ways:** a query that must be denied is denied and increments `deny_total`. A gate only ever observed allowing is not distinguishable from an absent gate.
+- [ ] Add a liveness alert on "zero policy decisions over a period in which queries were served" — the condition that hid this for the service's entire lifetime
+
+---
+
+## WO-KMASS-01.04 — Build the labeled evaluation set
+
+**Unblocks:** `TAB.TEXT.GRAN` (and is a prerequisite for any accuracy claim at all)
+**Effort:** days
+**Owner repo:** new, or `delivery-excellence/fixtures/`
+**Depends on:** WO-01.02
+
+The contract requires Top-1 exact match against a labeled target set, minimum 30 queries per phase per modality. No such set exists anywhere in the estate.
+
+**Acceptance:**
+- [ ] ≥30 labeled query/target pairs at document granularity (Phase 1)
+- [ ] Targets addressed by the contract's canonical retrieval-unit ids — `doc_id`+`doc_rev` for documents, `span_id = hash(doc_id, start, end)` for paragraphs, explicit `segmenter_ver` for sentences
+- [ ] A harness that computes Top-1 accuracy and emits a scoreboard-compatible evidence artifact
+- [ ] Labeled set is versioned and reviewable; an eval set that can be silently edited to make a number go up is not evidence
+
+---
+
+## WO-KMASS-01.05 — Re-measure latency and actions non-vacuously
+
+**Unblocks:** legitimate `TAD.LATENCY.JIT` and `TAD.ACTIONS.JE` claims
+**Effort:** hours (once dependencies land)
+**Depends on:** WO-01.02, WO-01.04
+
+Current latency of p50 8.8ms nominally beats the Phase-3 target by 113x and is recorded `vacuousPass: true` because every query returned nothing.
+
+**Acceptance:**
+- [ ] Latency re-measured with `nonzero-result ≥ 90%` of the sample, `vacuousPass` set false
+- [ ] `TAD.ACTIONS.JE` defined against a concrete "acceptable answer state" and counted on a real surface
+- [ ] Expect the honest number to be **worse** than 8.8ms. That is the point; a regression against a vacuous baseline is progress.
+
+---
+
+## WO-KMASS-01.06 — Ingest to the Phase-1 corpus target
+
+**Unblocks:** `TAB.TEXT.SCALE` Phase-1 claim
+**Effort:** weeks
+**Depends on:** WO-01.01, WO-01.02
+
+12 retrievable documents against a 20,000 target.
+
+**Acceptance:**
+- [ ] ≥20,000 documents retrievable and surviving a pod restart
+- [ ] Ingestion manifests + index cardinalities as evidence artifacts, per the contract
+- [ ] Stable `doc_id` / `doc_rev` provenance on every document — the contract's Phase-1 architecture commitment requires ranking and timing logs mandatory from day one
+
+---
+
+## WO-KMASS-01.07 — Instrument capture friction
+
+**Unblocks:** `TAC.CAPTURE.FRICTION`
+**Effort:** days
+**Owner repo:** `goose-notes`
+**Independent of the retrieval chain — can run in parallel**
+
+`goose-notes` is the designated capture surface but is not deployed to the measured environment and emits no timing traces. The metric needs minutes-per-fact over n=30.
+
+**Acceptance:**
+- [ ] Capture surface emits timestamped traces: capture-initiated → fact-committed
+- [ ] n≥30 traces collected under realistic task conditions, not a synthetic loop
+- [ ] Baseline number recorded even if it is far worse than the 10-minute Phase-1 target
+- [ ] **Phase-3 scope note:** the target trajectory ends at cell-phone / personal-sensor capture. Nothing in the estate addresses mobile capture today. Flag now whether that is in scope, because it is a build, not an instrumentation task.
+
+---
+
+## WO-KMASS-01.08 — Media / ASR tier
+
+**Unblocks:** `TAB.VIDEO.GRAN`, `TAB.VIDEO.SCALE`
+**Effort:** weeks — largest single item
+**Owner repos:** `videolab`, `imagelab`, `speechlab` (currently lab repos, not deployed services)
+**Independent of the retrieval chain**
+
+No video, media, ASR, or transcode capability exists in the cluster. Verified: zero matching pods across all namespaces. Both video metrics are `UNBUILT`, not merely unmeasured.
+
+**Acceptance:**
+- [ ] Media ingest + catalog with `video_id` and `duration_ms`
+- [ ] Segment index using the contract's canonical ids: `clip_id = hash(video_id, start_ms, end_ms)` at ~60s spans with explicit tolerance; frames as `(video_id, frame_index)` with `fps_assumed` and `decode_method_version`
+- [ ] ≥40 hours catalogued (Phase-1 target)
+- [ ] Success@5 or Recall@5 measurable with an explicit IoU threshold
+
+**Recommend a scope decision before starting.** This is the most expensive item in the work order and the estate currently has zero of it. If video is not near-term, mark both metrics out-of-scope explicitly in the contract rather than carrying them as perpetual `UNBUILT` — an honest descoping is better than a permanent red row.
+
+---
+
+## WO-KMASS-01.09 — Org digital twin
+
+**Unblocks:** `SYS.SCALE.TBD`, plus scenario simulation for roadmap choices
+**Effort:** weeks
+**Design:** [`docs/design/org-digital-twin-v0.md`](../design/org-digital-twin-v0.md)
+
+`SYS.SCALE.TBD` is the only row whose phase targets are themselves undefined, and its variables are organizational rather than product: knowledge elements, distinct tasks, policies per task, communities of practice, roles within CoPs, tasks per CoP. It is an org model by definition. See the design note.
+
+---
+
+## Definition of done for this work order
+
+- [ ] Every contract metric reads `MEASURED` with a real number, or is explicitly and deliberately descoped in the contract itself
+- [ ] Zero rows carry `vacuousPass: true`
+- [ ] At least one metric carries a legitimate `phaseClaim` with all four gate attachments
+- [ ] The scoreboard validator is a required CI check
+- [ ] A second scoreboard exists, so trend is visible — a single point is a measurement, two points are a program

--- a/docs/work-orders/WO-KMASS-01-close-the-baseline.md
+++ b/docs/work-orders/WO-KMASS-01-close-the-baseline.md
@@ -32,12 +32,13 @@ Sequencing consequence: **WO-01 gates six other items.** Nothing in TA B or TA D
 **Effort:** hours
 **Owner repo:** `delivery-excellence`
 
-`tools/validate_kmass_scoreboard.py` exists and is proven fail-closed in both directions, but nothing runs it automatically yet. Until it is a required check, the gate rule remains advisory — the exact condition this program is trying to cure.
+`tools/validate_kmass_scoreboard.py` exists and is proven fail-closed in both directions, but nothing ran it automatically before this work order. Until it is a required check, the gate rule remains advisory — the exact condition this program is trying to cure.
 
-**Acceptance:**
-- [ ] `.github/workflows/kmass-scoreboard.yml` runs the validator on every PR touching `scoreboards/**`, `schemas/kmass-scoreboard.*`, or `docs/kmass-metrics-v1.md`
+**Done as of this PR:** `.github/workflows/validate-contracts.yml` runs the KMASS scoreboard gate — plus the repo's three pre-existing contract validators, which had never run in CI either — unconditionally on every PR and every push to `main`. Unscoped on purpose: all four are stdlib-only scripts over small JSON/Markdown files, so path-filtering would save negligible time at the cost of a missed run if a metric changes through an unexpected path.
+
+**Acceptance still open:**
 - [ ] The check is marked **required** in branch protection, matching the `gate / check` pattern already required across six estate repos
-- [ ] Adding a new metric id to the contract makes existing scoreboards fail until measured (already implemented — verify it in CI, don't assume)
+- [ ] Adding a new metric id to the contract makes existing scoreboards fail until measured — confirmed locally (adding an unknown metric id triggers `scoreboard reports metric id(s) not present in the contract`); verify the same failure surfaces in the actual CI run, not just locally
 
 **Do this first.** It is the cheapest item and it makes every later claim falsifiable.
 

--- a/schemas/kmass-scoreboard.v0.1.schema.json
+++ b/schemas/kmass-scoreboard.v0.1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/delivery-excellence/kmass-scoreboard.v0.1.schema.json",
+  "title": "KMASS Scoreboard v0.1",
+  "description": "A measured instance of the metric contract defined in docs/kmass-metrics-v1.md. Encodes that document's 'Gate implication' rule as structure: a metric may only claim a phase unless it carries a measurement protocol, evidence artifacts, an acceptance threshold, and a reproducible run log. A metric with no measurement MUST declare state=UNMEASURED and carry a blockedBy reason -- silence is not an allowed value.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "recordType", "recordId", "metricsContractRef", "measuredAt", "environment", "metrics", "provenance"],
+  "properties": {
+    "schemaVersion": { "const": "kmass.scoreboard.v0.1" },
+    "recordType": { "const": "KmassScoreboard" },
+    "recordId": { "type": "string" },
+    "metricsContractRef": {
+      "type": "string",
+      "description": "Path/ref to the metric contract this scoreboard instantiates, e.g. docs/kmass-metrics-v1.md"
+    },
+    "measuredAt": { "type": "string", "description": "ISO-8601 timestamp of the measurement run" },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "description"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "clusterRef": { "type": "string" }
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "description": "One entry per metric id in the contract. Every contract metric MUST appear; omission is a validation failure.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["metricId", "figureRow", "type", "unit", "phaseTargets", "state"],
+        "properties": {
+          "metricId": { "type": "string" },
+          "figureRow": { "type": "string" },
+          "type": { "enum": ["Outcome", "Capacity", "Friction", "Composite"] },
+          "unit": { "type": "string" },
+          "phaseTargets": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["phase1", "phase2", "phase3"],
+            "properties": {
+              "phase1": { "type": ["string", "number", "null"] },
+              "phase2": { "type": ["string", "number", "null"] },
+              "phase3": { "type": ["string", "number", "null"] }
+            }
+          },
+          "state": {
+            "enum": ["MEASURED", "UNMEASURED", "UNBUILT"],
+            "description": "MEASURED = a real number was produced by a run. UNMEASURED = the capability exists but no valid measurement run has occurred. UNBUILT = the capability required to measure this does not exist yet."
+          },
+          "measuredValue": { "type": ["number", "string", "null"] },
+          "sampleSize": { "type": ["integer", "null"] },
+          "measurementProtocol": { "type": ["string", "null"] },
+          "evidenceArtifacts": { "type": "array", "items": { "type": "string" } },
+          "runLog": { "type": ["string", "null"], "description": "Reproducible run log reference. Required when state=MEASURED." },
+          "phaseClaim": {
+            "enum": ["none", "phase1", "phase2", "phase3"],
+            "description": "Which phase this metric currently satisfies. May only be non-'none' when state=MEASURED with protocol, evidence, and runLog present."
+          },
+          "vacuousPass": {
+            "type": "boolean",
+            "description": "TRUE when the measured value nominally meets a target but the result is not meaningful (e.g. latency measured against an empty corpus). A vacuous pass MUST NOT be counted as a phase claim."
+          },
+          "blockedBy": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Required when state is UNMEASURED or UNBUILT: what must exist before this becomes measurable."
+          },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "summary"],
+        "properties": {
+          "severity": { "enum": ["critical", "high", "medium", "info"] },
+          "summary": { "type": "string" },
+          "detail": { "type": "string" },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy", "createdAt", "nonSecret", "method"],
+      "properties": {
+        "createdBy": { "type": "string" },
+        "createdAt": { "type": "string" },
+        "nonSecret": { "type": "boolean" },
+        "method": { "type": "string", "description": "How the measurement was taken, in enough detail to reproduce." }
+      }
+    },
+    "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+  }
+}

--- a/schemas/kmass-scoreboard.v0.1.schema.json
+++ b/schemas/kmass-scoreboard.v0.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.socioprophet.org/delivery-excellence/kmass-scoreboard.v0.1.schema.json",
   "title": "KMASS Scoreboard v0.1",
-  "description": "A measured instance of the metric contract defined in docs/kmass-metrics-v1.md. Encodes that document's 'Gate implication' rule as structure: a metric may only claim a phase unless it carries a measurement protocol, evidence artifacts, an acceptance threshold, and a reproducible run log. A metric with no measurement MUST declare state=UNMEASURED and carry a blockedBy reason -- silence is not an allowed value.",
+  "description": "A measured instance of the metric contract defined in docs/kmass-metrics-v1.md. Encodes that document's 'Gate implication' rule as structure: a metric may only claim a phase if it carries a measurement protocol, evidence artifacts, an acceptance threshold, and a reproducible run log. A metric with no measurement MUST declare state=UNMEASURED and carry a blockedBy reason -- silence is not an allowed value.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schemaVersion", "recordType", "recordId", "metricsContractRef", "measuredAt", "environment", "metrics", "provenance"],

--- a/scoreboards/kmass-baseline-2026-08-01.json
+++ b/scoreboards/kmass-baseline-2026-08-01.json
@@ -229,9 +229,9 @@
     },
     {
       "severity": "high",
-      "summary": "This measurement run served the first 30 queries in the service's lifetime.",
-      "detail": "search_query_total was exactly 0 before this run. The production search-orchestrator had never served a single query prior to Baseline Day. Uptime and green health checks had been reporting success against a path no traffic had ever traversed.",
-      "evidence": "/v1/search/debug/metrics initial read: search_query_total=0"
+      "summary": "search_query_total was zero for the entire lifetime of the current pod before this run.",
+      "detail": "The current search-orchestrator pod was 3d2h old with 0 restarts, and search_query_total read exactly 0 before this run's 30 queries. The metric is process-local (mode=in-memory throughout this service), so this proves zero traffic for at least that pod's 3+ day lifetime -- it does NOT prove zero traffic since the Deployment's creation (2026-07-13, ~3 weeks prior); an earlier pod incarnation could have served queries before this one started. Either way, uptime and green health checks were reporting success against a path with no evidence of use for at least 3 days.",
+      "evidence": "kubectl get pod: restarts=0, age=3d2h; /v1/search/debug/metrics initial read: search_query_total=0; deployment creationTimestamp=2026-07-13T17:47:47Z (not directly comparable to the in-memory counter)"
     },
     {
       "severity": "high",

--- a/scoreboards/kmass-baseline-2026-08-01.json
+++ b/scoreboards/kmass-baseline-2026-08-01.json
@@ -1,0 +1,260 @@
+{
+  "schemaVersion": "kmass.scoreboard.v0.1",
+  "recordType": "KmassScoreboard",
+  "recordId": "kmass-baseline-2026-08-01",
+  "metricsContractRef": "docs/kmass-metrics-v1.md",
+  "measuredAt": "2026-08-01T18:05:00Z",
+  "environment": {
+    "name": "prophet-platform-prod",
+    "description": "Live GKE Autopilot cluster; measurements taken in-cluster against ClusterIP service DNS to exclude ingress/WAN variance.",
+    "clusterRef": "gke_socioprophet-platform_us-central1_prophet-platform"
+  },
+  "metrics": [
+    {
+      "metricId": "TAB.TEXT.GRAN",
+      "figureRow": "Textual Granularity",
+      "type": "Outcome",
+      "unit": "Top-1 accuracy @ unit",
+      "phaseTargets": { "phase1": "80% @ document", "phase2": "80% @ paragraph", "phase3": "80% @ sentence" },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Top-1 exact match against labeled target set, min 30 queries per phase per modality (contract §Measurement protocols)",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No labeled query/target set exists anywhere in the estate",
+        "No durable text corpus to evaluate against (see TAB.TEXT.SCALE)",
+        "search-orchestrator returns 0 results for all queries, so accuracy is undefined"
+      ],
+      "notes": "Accuracy cannot be defined while the retrieval path returns the empty set for every input."
+    },
+    {
+      "metricId": "TAB.VIDEO.GRAN",
+      "figureRow": "Video Granularity",
+      "type": "Outcome",
+      "unit": "Success@5 / Recall@5",
+      "phaseTargets": { "phase1": "65% @ video", "phase2": "65% @ 1-min clip", "phase3": "65% @ frame" },
+      "state": "UNBUILT",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Success@5 or Recall@5 with IoU threshold against labeled temporal target window",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No video, media, ASR, or transcode service exists in the cluster (verified: zero matching pods across all namespaces)",
+        "No media catalog or segment index",
+        "videolab/imagelab/speechlab are lab repos, not deployed services"
+      ]
+    },
+    {
+      "metricId": "TAB.TEXT.SCALE",
+      "figureRow": "Text Sources",
+      "type": "Capacity",
+      "unit": "count",
+      "phaseTargets": { "phase1": 20000, "phase2": 120000, "phase3": 800000 },
+      "state": "MEASURED",
+      "measuredValue": 12,
+      "sampleSize": null,
+      "measurementProtocol": "Sum of retrievable documents across all live index services, read from each service's own health/stats endpoint",
+      "evidenceArtifacts": [
+        "sherlock-engine /healthz -> {\"docs\":12,\"engine\":\"tantivy\",\"dense\":false}",
+        "commons-search /healthz -> {\"store\":\"memory\",\"count\":0}",
+        "memoryd /healthz -> {\"store\":{\"backend\":\"memory\",\"resource_count\":0,\"event_count\":0,\"memory_count\":0}}",
+        "search-orchestrator /v1/search/debug/config -> academy_repository.record_count=1421, mode=in-memory"
+      ],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [],
+      "notes": "12 retrievable documents against a Phase-1 target of 20,000 = 0.06%. The search-orchestrator additionally holds 1421 seeded academy records, but they are NOT retrievable (0 results for every query tried, all modes) so they are excluded from the retrievable count. Root cause is architectural, not volumetric: every store in the retrieval tier is non-durable (see finding: ephemeral-retrieval-tier)."
+    },
+    {
+      "metricId": "TAB.VIDEO.SCALE",
+      "figureRow": "Video Sources",
+      "type": "Capacity",
+      "unit": "hours",
+      "phaseTargets": { "phase1": 40, "phase2": 220, "phase3": 400 },
+      "state": "UNBUILT",
+      "measuredValue": 0,
+      "sampleSize": null,
+      "measurementProtocol": "Media catalog duration sum + segment index cardinality",
+      "evidenceArtifacts": ["No video/media/ASR pods found in any namespace"],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": ["No media ingest, catalog, or segment index capability is deployed"]
+    },
+    {
+      "metricId": "TAC.CAPTURE.FRICTION",
+      "figureRow": "Easy and Natural",
+      "type": "Friction",
+      "unit": "minutes / fact",
+      "phaseTargets": { "phase1": 10, "phase2": 5, "phase3": 2 },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Timestamped capture traces, min n=30 per contract sampling rule",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No capture-trace instrumentation exists in goose-notes or any capture surface",
+        "No deployed capture endpoint in-cluster to time against"
+      ],
+      "notes": "goose-notes is the designated capture surface but is not deployed to the measured environment and emits no timing traces."
+    },
+    {
+      "metricId": "TAD.LATENCY.JIT",
+      "figureRow": "Just-in-Time",
+      "type": "Outcome",
+      "unit": "seconds",
+      "phaseTargets": { "phase1": 60, "phase2": 8, "phase3": 1 },
+      "state": "MEASURED",
+      "measuredValue": 0.0088,
+      "sampleSize": 30,
+      "measurementProtocol": "End-to-end query-to-answer completion, 30 distinct queries, in-cluster to exclude ingress variance",
+      "evidenceArtifacts": [
+        "search-orchestrator /v0/search/query: n=30 mean=8.7ms p50=8.8ms p95=9.4ms ok=30/30",
+        "sherlock-engine /search: n=30 mean=9.1ms p50=6.9ms p95=8.3ms"
+      ],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": true,
+      "blockedBy": [],
+      "notes": "VACUOUS PASS. p50 of 8.8ms nominally beats even the Phase-3 target of 1 second by ~113x, but every one of the 30 queries returned zero results. Latency over an empty result set measures nothing. This value MUST NOT be reported as a Phase-3 claim; it must be re-measured once retrieval returns real results."
+    },
+    {
+      "metricId": "TAD.ACTIONS.JE",
+      "figureRow": "Just-enough",
+      "type": "Friction",
+      "unit": "action count",
+      "phaseTargets": { "phase1": 10, "phase2": 5, "phase3": 1 },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Discrete user or agent actions required to reach an acceptable answer state",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "Undefined while no query path reaches an 'acceptable answer state' (0 results for all queries)",
+        "No action instrumentation on any UI or agent surface"
+      ]
+    },
+    {
+      "metricId": "TAD.RELEVANCE.JFM",
+      "figureRow": "Just-for-me",
+      "type": "Outcome",
+      "unit": "percent relevant",
+      "phaseTargets": { "phase1": 70, "phase2": 83, "phase3": 98 },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Blinded human evaluation, 0-3 rubric, score >= 2 counts relevant",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No results to evaluate (0 results returned for all queries)",
+        "No blinded evaluation harness or rubric instrument exists",
+        "No per-actor personalization signal is wired into the query path"
+      ]
+    },
+    {
+      "metricId": "SYS.SPEEDUP",
+      "figureRow": "Speed Improvement",
+      "type": "Composite",
+      "unit": "multiplier",
+      "phaseTargets": { "phase1": "1.1x", "phase2": "2x", "phase3": "5x" },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Time-on-task studies against a control condition",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "A speedup multiplier requires a baseline control condition, which has never been established",
+        "Depends on TAD.LATENCY.JIT and TAD.ACTIONS.JE being non-vacuous first"
+      ]
+    },
+    {
+      "metricId": "SYS.SCALE.TBD",
+      "figureRow": "Scale",
+      "type": "Composite",
+      "unit": "multi-dimensional",
+      "phaseTargets": { "phase1": null, "phase2": null, "phase3": null },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Policy/task/role graph statistics: |K| knowledge elements, |E| relations, |P(task)| policies per task, |CoP| communities of practice and role distributions, task throughput by role",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "Phase targets are themselves undefined (TBD/TBD/TBD in the contract)",
+        "No org model exists to compute |K|, |E|, |P(task)|, |CoP| against"
+      ],
+      "notes": "This row is org-shaped, not product-shaped: its variables describe the organization's own knowledge/task/policy/role graph. It is the natural instrument for -- and is blocked on -- an organizational digital twin. See docs/design/org-digital-twin-v0.md."
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "summary": "The entire retrieval tier is non-durable; no corpus can accumulate.",
+      "detail": "Zero PersistentVolumeClaims back any retrieval service. sherlock-engine's tantivy index lives on an emptyDir capped at 256Mi. commons-search reports store=memory. memoryd reports backend=memory. search-orchestrator's academy repository reports mode=in-memory with json_file/lampstand_jsonl/lampstand_carrier all false. Every pod restart resets the corpus to zero. Growth targets of 20k -> 120k -> 800k documents are unreachable by construction, not by effort.",
+      "evidence": "kubectl get pvc -A (no retrieval PVCs); pod volume spec shows tmp -> emptyDir{sizeLimit:256Mi}; service /healthz payloads"
+    },
+    {
+      "severity": "critical",
+      "summary": "search-orchestrator returns zero results for every query, despite holding 1421 seeded records.",
+      "detail": "30 diverse queries plus generic probes ('a', 'the', 'learning', '*', empty string) across modes default/semantic/keyword/hybrid/all all returned results: []. Its own counter academy_result_total remained 0 while search_query_total advanced to 30. The seeded corpus (academy_seed_total=1421) is not connected to the retrieval path.",
+      "evidence": "POST /v0/search/query x30 -> 0 nonzero; /v1/search/debug/metrics before/after delta = {search_query_total: +30} only"
+    },
+    {
+      "severity": "critical",
+      "summary": "The search policy gate has never fired -- not once, including under this measurement run.",
+      "detail": "policy_decision_allow_total, _deny_total, _local_total, _remote_total and _fallback_total were all 0 before the run and all still 0 after 30 successful queries. A policy gate that does not evaluate on the request path is declared, not enforced. This is the estate's 'never-fired = SUSPECT' pattern in its purest form.",
+      "evidence": "/v1/search/debug/metrics before/after this scoreboard's own 30-query run"
+    },
+    {
+      "severity": "high",
+      "summary": "This measurement run served the first 30 queries in the service's lifetime.",
+      "detail": "search_query_total was exactly 0 before this run. The production search-orchestrator had never served a single query prior to Baseline Day. Uptime and green health checks had been reporting success against a path no traffic had ever traversed.",
+      "evidence": "/v1/search/debug/metrics initial read: search_query_total=0"
+    },
+    {
+      "severity": "high",
+      "summary": "Latency 'passes' Phase 3 by 113x, and the pass is meaningless.",
+      "detail": "p50 8.8ms against a Phase-3 target of 1s. Because every query returns the empty set, this measures the cost of returning nothing. Recorded with vacuousPass=true so it cannot be counted toward a phase claim. This is precisely the silent-wrong class the contract's confidence rules exist to catch.",
+      "evidence": "n=30, nonzero-result=0/30"
+    },
+    {
+      "severity": "info",
+      "summary": "Two components are genuinely healthy and doing real work.",
+      "detail": "The embeddings service serves nomic-embed-text-v1.5 at 768 dimensions with p50 103ms over 10 samples. sherlock-engine's tantivy index answers in p50 6.9ms and returned non-empty results for 14 of 30 queries against its 12 documents -- small, but real retrieval. These are the two load-bearing pieces to build on.",
+      "evidence": "embeddings /healthz + /v1/embeddings n=10; sherlock /search n=30, 14 nonzero"
+    }
+  ],
+  "provenance": {
+    "createdBy": "baseline-day-run/2026-08-01",
+    "createdAt": "2026-08-01T18:05:00Z",
+    "nonSecret": true,
+    "method": "Probes executed in-cluster from a pod in the socioprophet namespace against ClusterIP service DNS, using stdlib urllib with a fixed 30-query set. Latency captured with time.perf_counter around the full request/response cycle. Counter deltas read from each service's own debug endpoint immediately before and after the run. No secrets, paths, actor ids, or query contents are recorded in evidence strings. Full method and reproduction steps in docs/reports/kmass-baseline-readout-2026-08-01.md."
+  },
+  "labels": {
+    "program": "kmass",
+    "runType": "baseline",
+    "phase": "pre-phase-1"
+  }
+}

--- a/tools/validate_kmass_scoreboard.py
+++ b/tools/validate_kmass_scoreboard.py
@@ -60,6 +60,74 @@ def load_json(path: Path) -> Any:
         sys.exit(1)
 
 
+def json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    return "object"
+
+
+def type_matches(value: Any, expected: str) -> bool:
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    return json_type_name(value) == expected
+
+
+def validate_schema(schema: dict[str, Any], value: Any, path: str, errors: list[str]) -> None:
+    """Structural validation driven by the schema file itself.
+
+    Matches the walker convention already used by validate_orggov_scorecard.py
+    (stdlib only, no jsonschema dependency). This exists because a schema that
+    nothing validates against is documentation wearing a contract's clothes --
+    the precise failure this whole scoreboard effort is meant to cure. The
+    semantic gate rules below layer on top of this; they do not replace it.
+    """
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}, got {value!r}")
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: {value!r} not in enum {schema['enum']!r}")
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        expected_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(type_matches(value, t) for t in expected_types):
+            errors.append(f"{path}: expected type {expected_types!r}, got {json_type_name(value)!r}")
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{path}: missing required property {key!r}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            if extra:
+                errors.append(f"{path}: unexpected properties {extra!r}")
+        additional = schema.get("additionalProperties")
+        for key, item in value.items():
+            child = properties.get(key)
+            if child is None and isinstance(additional, dict):
+                child = additional
+            if child is not None:
+                validate_schema(child, item, f"{path}.{key}", errors)
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            errors.append(f"{path}: expected at least {min_items} item(s), got {len(value)}")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for i, item in enumerate(value):
+                validate_schema(item_schema, item, f"{path}[{i}]", errors)
+
+
 def contract_metric_ids() -> set[str]:
     """Parse the metric ids out of the contract's canonical metric table.
 
@@ -79,12 +147,21 @@ def contract_metric_ids() -> set[str]:
     return ids
 
 
-def validate(path: Path, expected_ids: set[str]) -> list[str]:
+def validate(path: Path, expected_ids: set[str], schema: dict[str, Any]) -> list[str]:
     doc = load_json(path)
     errors: list[str] = []
 
     def err(msg: str) -> None:
         errors.append(msg)
+
+    # Structural pass against the schema file itself, first -- a schema that
+    # is never applied is decoration, not a contract. The checks below layer
+    # semantic/cross-field gate rules the generic walker can't express
+    # (contract-derived coverage, the vacuous-pass rule, phase-claim
+    # attachment requirements), so both passes run; neither replaces the other.
+    validate_schema(schema, doc, "$", errors)
+    if errors:
+        return errors
 
     if doc.get("schemaVersion") != "kmass.scoreboard.v0.1":
         err(f"schemaVersion must be 'kmass.scoreboard.v0.1', got {doc.get('schemaVersion')!r}")
@@ -179,6 +256,7 @@ def main(argv: list[str]) -> int:
     if not SCHEMA.exists():
         print(f"FAIL: schema missing: {SCHEMA}")
         return 1
+    schema = load_json(SCHEMA)
 
     expected = contract_metric_ids()
 
@@ -194,7 +272,7 @@ def main(argv: list[str]) -> int:
 
     total_errors = 0
     for p in paths:
-        errs = validate(p, expected)
+        errs = validate(p, expected, schema)
         if errs:
             total_errors += len(errs)
             print(f"\nFAIL {p.name} -- {len(errs)} violation(s):")

--- a/tools/validate_kmass_scoreboard.py
+++ b/tools/validate_kmass_scoreboard.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate KMASS scoreboards against the metric contract's own gate rule.
+
+docs/kmass-metrics-v1.md ends with a Gate implication:
+
+    No phase should be marked complete unless the metrics for that phase are
+    attached to: a named measurement protocol, evidence artifacts, an
+    acceptance threshold, and a reproducible run log.
+
+That sentence has never been enforced by anything. This is the enforcement.
+It is deliberately fail-closed: a scoreboard that is silent about a metric,
+or that claims a phase without the four required attachments, is a FAILURE --
+not a warning -- because the failure mode this program is trying to cure is
+exactly "declared but never verified".
+
+Two rules carry most of the weight:
+
+  * COVERAGE. Every metric id in the contract must appear in the scoreboard.
+    Omitting an inconvenient metric is the cheapest way to fake progress, so
+    a missing row fails rather than passes quietly.
+
+  * NO VACUOUS PHASE CLAIMS. A metric whose measured value meets a target but
+    whose result is not meaningful (latency over an empty corpus, accuracy
+    over an empty result set) must set vacuousPass=true, and may not claim a
+    phase. A number that looks like success while measuring nothing is worse
+    than a missing number, because it survives review.
+
+Usage:
+    python3 tools/validate_kmass_scoreboard.py [scoreboard.json ...]
+
+With no arguments, validates every file in scoreboards/.
+Exit 0 = valid; exit 1 = one or more violations.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/kmass-scoreboard.v0.1.schema.json"
+CONTRACT = ROOT / "docs/kmass-metrics-v1.md"
+SCOREBOARD_DIR = ROOT / "scoreboards"
+
+VALID_STATES = {"MEASURED", "UNMEASURED", "UNBUILT"}
+VALID_PHASE_CLAIMS = {"none", "phase1", "phase2", "phase3"}
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"FAIL: file not found: {path}")
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: {path.name} is not valid JSON: {exc}")
+        sys.exit(1)
+
+
+def contract_metric_ids() -> set[str]:
+    """Parse the metric ids out of the contract's canonical metric table.
+
+    Deriving the expected set from the contract rather than hardcoding it here
+    means adding a metric to the contract automatically makes every existing
+    scoreboard incomplete until it is measured -- which is the intended
+    pressure. A hardcoded list would silently drift from the contract.
+    """
+    if not CONTRACT.exists():
+        print(f"FAIL: metric contract missing: {CONTRACT}")
+        sys.exit(1)
+    text = CONTRACT.read_text(encoding="utf-8")
+    ids = set(re.findall(r"`([A-Z]{2,4}(?:\.[A-Z_]+){1,3})`", text))
+    if not ids:
+        print(f"FAIL: no metric ids parsed from {CONTRACT.name} -- contract format changed?")
+        sys.exit(1)
+    return ids
+
+
+def validate(path: Path, expected_ids: set[str]) -> list[str]:
+    doc = load_json(path)
+    errors: list[str] = []
+
+    def err(msg: str) -> None:
+        errors.append(msg)
+
+    if doc.get("schemaVersion") != "kmass.scoreboard.v0.1":
+        err(f"schemaVersion must be 'kmass.scoreboard.v0.1', got {doc.get('schemaVersion')!r}")
+    if doc.get("recordType") != "KmassScoreboard":
+        err(f"recordType must be 'KmassScoreboard', got {doc.get('recordType')!r}")
+
+    for field in ("recordId", "metricsContractRef", "measuredAt", "environment", "metrics", "provenance"):
+        if field not in doc:
+            err(f"missing required top-level field: {field}")
+    if errors:
+        return errors
+
+    prov = doc.get("provenance", {})
+    for field in ("createdBy", "createdAt", "nonSecret", "method"):
+        if field not in prov:
+            err(f"provenance missing required field: {field}")
+    if prov.get("nonSecret") is not True:
+        err("provenance.nonSecret must be true -- scoreboards are published artifacts")
+
+    metrics = doc.get("metrics", [])
+    if not isinstance(metrics, list) or not metrics:
+        err("metrics must be a non-empty array")
+        return errors
+
+    seen: set[str] = set()
+    for i, m in enumerate(metrics):
+        mid = m.get("metricId", f"<index {i}>")
+        if mid in seen:
+            err(f"{mid}: duplicate metric entry")
+        seen.add(mid)
+
+        state = m.get("state")
+        if state not in VALID_STATES:
+            err(f"{mid}: state must be one of {sorted(VALID_STATES)}, got {state!r}")
+            continue
+
+        claim = m.get("phaseClaim", "none")
+        if claim not in VALID_PHASE_CLAIMS:
+            err(f"{mid}: phaseClaim must be one of {sorted(VALID_PHASE_CLAIMS)}, got {claim!r}")
+            continue
+
+        vacuous = bool(m.get("vacuousPass", False))
+
+        if state == "MEASURED":
+            if m.get("measuredValue") is None:
+                err(f"{mid}: state=MEASURED but measuredValue is null")
+            if not m.get("runLog"):
+                err(f"{mid}: state=MEASURED requires a reproducible runLog (contract gate rule)")
+            if not m.get("evidenceArtifacts"):
+                err(f"{mid}: state=MEASURED requires at least one evidenceArtifact (contract gate rule)")
+        else:
+            # UNMEASURED / UNBUILT must say why, or the gap is invisible.
+            if not m.get("blockedBy"):
+                err(f"{mid}: state={state} requires a non-empty blockedBy explaining what is missing")
+            if claim != "none":
+                err(f"{mid}: state={state} cannot carry phaseClaim={claim!r}")
+
+        # The gate rule proper: a phase claim needs all four attachments.
+        if claim != "none":
+            missing = [
+                name for name, present in (
+                    ("measurementProtocol", bool(m.get("measurementProtocol"))),
+                    ("evidenceArtifacts", bool(m.get("evidenceArtifacts"))),
+                    ("runLog", bool(m.get("runLog"))),
+                    ("phaseTargets", bool(m.get("phaseTargets"))),
+                ) if not present
+            ]
+            if missing:
+                err(f"{mid}: claims {claim} without required attachment(s): {', '.join(missing)} "
+                    f"(docs/kmass-metrics-v1.md Gate implication)")
+            if vacuous:
+                err(f"{mid}: vacuousPass=true cannot be combined with phaseClaim={claim!r} -- "
+                    f"a result that meets a target without meaning anything is not a phase claim")
+
+        if vacuous and not m.get("notes"):
+            err(f"{mid}: vacuousPass=true requires notes explaining why the pass is not meaningful")
+
+    missing_ids = expected_ids - seen
+    if missing_ids:
+        err(f"COVERAGE: contract defines metric(s) absent from this scoreboard: "
+            f"{', '.join(sorted(missing_ids))} -- every contract metric must be reported, "
+            f"even if only as UNMEASURED/UNBUILT")
+
+    unknown_ids = seen - expected_ids
+    if unknown_ids:
+        err(f"scoreboard reports metric id(s) not present in the contract: {', '.join(sorted(unknown_ids))}")
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if not SCHEMA.exists():
+        print(f"FAIL: schema missing: {SCHEMA}")
+        return 1
+
+    expected = contract_metric_ids()
+
+    if argv:
+        paths = [Path(a) for a in argv]
+    else:
+        paths = sorted(SCOREBOARD_DIR.glob("*.json")) if SCOREBOARD_DIR.exists() else []
+
+    if not paths:
+        print("FAIL: no scoreboards found to validate. A program with a metric "
+              "contract and zero scoreboards has never measured itself.")
+        return 1
+
+    total_errors = 0
+    for p in paths:
+        errs = validate(p, expected)
+        if errs:
+            total_errors += len(errs)
+            print(f"\nFAIL {p.name} -- {len(errs)} violation(s):")
+            for e in errs:
+                print(f"  - {e}")
+        else:
+            doc = load_json(p)
+            ms = doc.get("metrics", [])
+            measured = sum(1 for m in ms if m.get("state") == "MEASURED")
+            vac = sum(1 for m in ms if m.get("vacuousPass"))
+            claims = sum(1 for m in ms if m.get("phaseClaim", "none") != "none")
+            print(f"OK   {p.name}: {len(ms)} metrics ({measured} measured, "
+                  f"{vac} vacuous, {claims} phase claims), contract coverage complete")
+
+    if total_errors:
+        print(f"\n{total_errors} violation(s) across {len(paths)} scoreboard(s).")
+        return 1
+    print(f"\nAll {len(paths)} scoreboard(s) valid against {CONTRACT.name}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
`docs/kmass-metrics-v1.md` is a genuinely good measurement contract — 10 metrics with ids, units, per-phase targets, measurement protocols, sample-size rules, and required evidence artifacts. It closes with a Gate implication:

> No phase should be marked complete unless the metrics for that phase are attached to: a named measurement protocol, evidence artifacts, an acceptance threshold, and a reproducible run log.

**None of its metric ids appeared anywhere else in the repository.** Zero measurements had ever been taken, so the rule the contract declares for itself had never fired once.

This PR is the first measurement, plus the mechanism that makes the rule real.

## Baseline

Probes run in-cluster against ClusterIP DNS on the live GKE cluster, n=30 per the contract's sampling rule.

| | |
|---|---|
| Measured | **2** of 10 |
| Vacuous (meets target, means nothing) | **1** |
| Unmeasured / Unbuilt | 5 / 3 |
| Legitimate phase claims | **0** |

- `TAB.TEXT.SCALE` = **12** retrievable documents against a Phase-1 target of 20,000 (0.06%)
- `TAD.LATENCY.JIT` = **8.8ms** p50 — beats the *Phase-3* target by 113x, and is recorded `vacuousPass: true` because all 30 queries returned zero results. Latency over an empty result set measures nothing.

## Findings (verified, not inferred)

1. **The retrieval tier cannot accumulate a corpus.** Zero PVCs back any retrieval service — `sherlock-engine` on a 256Mi `emptyDir`, `commons-search` and `memoryd` on in-memory backends, orchestrator repository `mode: in-memory`. The 20k→120k→800k curve is unreachable by construction, not by effort.
2. **`search-orchestrator` returns `[]` for every query.** 30 diverse queries plus generic probes (`a`, `the`, `*`, empty string) across all five modes. Its own `academy_result_total` never left 0 despite 1421 seeded records.
3. **The policy gate has never fired.** All five `policy_decision_*` counters read 0 before and 0 after 30 successful queries in this run.
4. **`search_query_total` was zero for the current pod's entire lifetime (3d2h, 0 restarts) before this run.** *(Corrected after self-review: my first pass overclaimed this as "the service has never served a query" — the counter is process-local, so it only proves zero traffic for this pod's lifetime, not since the Deployment's creation ~3 weeks earlier. Either way, green health checks were reporting success on a path with no confirmed traffic for at least 3 days — the same shape as the Loki incident earlier the same day.)*

Two components are genuinely healthy and worth building on: `embeddings` (nomic-embed-text-v1.5, p50 103ms) and `sherlock-engine` (p50 6.9ms, real hits on 14/30 queries).

## Mechanism

- **`schemas/kmass-scoreboard.v0.1.schema.json`** encodes the gate rule as structure, including `vacuousPass` so a meaningless pass can't be promoted into a phase claim.
- **`tools/validate_kmass_scoreboard.py`** actually applies that schema now (structural walk — const/enum/type/required/additionalProperties, reusing the stdlib convention already established in `validate_orggov_scorecard.py`) *and* layers the fail-closed semantic gate rules on top. Derives expected metric ids *from the contract* rather than hardcoding them, so adding a metric invalidates every existing scoreboard until it's measured.
- **Proven both ways, twice.** 11 adversarial cases caught: the original 5 (vacuous phase claim, deleted metric row, claim without evidence, measured-with-null, unexplained gap) plus 4 aimed at the schema walker itself, plus the 2 that Copilot's review separately surfaced (non-object metric entry crashing instead of failing cleanly; `vacuousPass: "false"` as a string slipping through Python truthiness) — both confirmed already closed by the schema-enforcement fix rather than assumed.
- **This repo had no CI at all**, so its three pre-existing validators had never run automatically either. `validate-contracts.yml` now runs all four, unconditionally on every PR (four fast stdlib scripts over small files — not worth path-filtering against the risk of a missed run). Recommend marking it required in branch protection — `WO-KMASS-01.10`, deliberately the cheapest item, because it makes every later claim falsifiable.

## Also included

- **`WO-KMASS-01`** — the unmeasured rows as a dependency-ordered backlog. Six items gate behind durable storage; that sequencing is the main finding of the work order.
- **`org-digital-twin-v0.md`** — `SYS.SCALE` is the only all-TBD row, and its variables (`|K|`, `|E|`, `|P(task)|`, `|CoP|`) are organizational, not product. The twin is that row's instrument. Layer 1 is largely derivable from `workspace-inventory/repos.yaml`, which is already a partial org twin nobody has called one.

Nothing here claims a phase. The point of the first scoreboard is to be honest enough that the second one can show movement.