### PR TITLE
feat(org-twin): Layer 1 inventory graph extractor, first SYS.SCALE measurement

### DIFF
--- a/scoreboards/artifacts/org-twin-layer1-2026-08-04.json
+++ b/scoreboards/artifacts/org-twin-layer1-2026-08-04.json
@@ -1,0 +1,2035 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "repo:SocioProphet/socioprophet",
+        "type": "repo",
+        "name": "socioprophet",
+        "org": "SocioProphet",
+        "authority_role": "public_surface",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:web_portal",
+        "type": "capability",
+        "name": "web_portal",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:api",
+        "type": "capability",
+        "name": "api",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:mcp_servers",
+        "type": "capability",
+        "name": "mcp_servers",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/workspace-inventory",
+        "type": "repo",
+        "name": "workspace-inventory",
+        "org": "SocioProphet",
+        "authority_role": "repository_index",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:repo_index",
+        "type": "capability",
+        "name": "repo_index",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:inventory_validation",
+        "type": "capability",
+        "name": "inventory_validation",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/sociosphere",
+        "type": "repo",
+        "name": "sociosphere",
+        "org": "SocioProphet",
+        "authority_role": "workspace_controller",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:workspace_manifest",
+        "type": "capability",
+        "name": "workspace_manifest",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:workspace_lock",
+        "type": "capability",
+        "name": "workspace_lock",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:runner_semantics",
+        "type": "capability",
+        "name": "runner_semantics",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/agentplane",
+        "type": "repo",
+        "name": "agentplane",
+        "org": "SocioProphet",
+        "authority_role": "execution_control_plane",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:bundle_execution",
+        "type": "capability",
+        "name": "bundle_execution",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:evidence_artifacts",
+        "type": "capability",
+        "name": "evidence_artifacts",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:replay",
+        "type": "capability",
+        "name": "replay",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/prophet-platform",
+        "type": "repo",
+        "name": "prophet-platform",
+        "org": "SocioProphet",
+        "authority_role": "platform_runtime",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:platform_apps",
+        "type": "capability",
+        "name": "platform_apps",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:contracts",
+        "type": "capability",
+        "name": "contracts",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:telemetry",
+        "type": "capability",
+        "name": "telemetry",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/prophet-core-catalog",
+        "type": "repo",
+        "name": "prophet-core-catalog",
+        "org": "SocioProphet",
+        "authority_role": "provenance_catalog_seed",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:catalog",
+        "type": "capability",
+        "name": "catalog",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:provenance_index",
+        "type": "capability",
+        "name": "provenance_index",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/ontogenesis",
+        "type": "repo",
+        "name": "ontogenesis",
+        "org": "SocioProphet",
+        "authority_role": "ontology_authority",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:capd:ontogenesis",
+        "type": "capability",
+        "name": "capd:ontogenesis",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/socioprophet-standards-storage",
+        "type": "repo",
+        "name": "socioprophet-standards-storage",
+        "org": "SocioProphet",
+        "authority_role": "standards_storage",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:schemas",
+        "type": "capability",
+        "name": "schemas",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:evidence_contracts",
+        "type": "capability",
+        "name": "evidence_contracts",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:control_plane_standards",
+        "type": "capability",
+        "name": "control_plane_standards",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "type": "repo",
+        "name": "socioprophet-standards-knowledge",
+        "org": "SocioProphet",
+        "authority_role": "knowledge_context_standards",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:knowledge_schemas",
+        "type": "capability",
+        "name": "knowledge_schemas",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:tritrpc_bindings",
+        "type": "capability",
+        "name": "tritrpc_bindings",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:roundtrip_verifiers",
+        "type": "capability",
+        "name": "roundtrip_verifiers",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/tritrpc",
+        "type": "repo",
+        "name": "tritrpc",
+        "org": "SocioProphet",
+        "authority_role": "transport_protocol",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:transport",
+        "type": "capability",
+        "name": "transport",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:fixtures",
+        "type": "capability",
+        "name": "fixtures",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:framing",
+        "type": "capability",
+        "name": "framing",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/sourceos-a2a-mcp-bootstrap",
+        "type": "repo",
+        "name": "sourceos-a2a-mcp-bootstrap",
+        "org": "SocioProphet",
+        "authority_role": "identity_bootstrap",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:carrier_verify",
+        "type": "capability",
+        "name": "carrier_verify",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/human-digital-twin",
+        "type": "repo",
+        "name": "human-digital-twin",
+        "org": "SocioProphet",
+        "authority_role": "hdt_consumer",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:api:hdt",
+        "type": "capability",
+        "name": "api:hdt",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:opa:policies",
+        "type": "capability",
+        "name": "opa:policies",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:tritrpc:devine",
+        "type": "capability",
+        "name": "tritrpc:devine",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/cloudshell-fog",
+        "type": "repo",
+        "name": "cloudshell-fog",
+        "org": "SocioProphet",
+        "authority_role": "hmi_gateway",
+        "status": "held",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:cloud_shell",
+        "type": "capability",
+        "name": "cloud_shell",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:operator_gateway",
+        "type": "capability",
+        "name": "operator_gateway",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SociOS-Linux/SourceOS",
+        "type": "repo",
+        "name": "SourceOS",
+        "org": "SociOS-Linux",
+        "authority_role": "immutable_substrate",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:substrate",
+        "type": "capability",
+        "name": "substrate",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:truth_plane",
+        "type": "capability",
+        "name": "truth_plane",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SociOS-Linux/socios",
+        "type": "repo",
+        "name": "socios",
+        "org": "SociOS-Linux",
+        "authority_role": "automation_commons",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:ci_cd",
+        "type": "capability",
+        "name": "ci_cd",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:build_automation",
+        "type": "capability",
+        "name": "build_automation",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:catalogs",
+        "type": "capability",
+        "name": "catalogs",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:signatures",
+        "type": "capability",
+        "name": "signatures",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SociOS-Linux/workstation-contracts",
+        "type": "repo",
+        "name": "workstation-contracts",
+        "org": "SociOS-Linux",
+        "authority_role": "workstation_ci_contracts",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:lane_contracts",
+        "type": "capability",
+        "name": "lane_contracts",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:conformance",
+        "type": "capability",
+        "name": "conformance",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/sourceos-spec",
+        "type": "repo",
+        "name": "sourceos-spec",
+        "org": "SourceOS-Linux",
+        "authority_role": "typed_contract_authority",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:json_schemas",
+        "type": "capability",
+        "name": "json_schemas",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:openapi_patches",
+        "type": "capability",
+        "name": "openapi_patches",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:asyncapi_patches",
+        "type": "capability",
+        "name": "asyncapi_patches",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:semantic_overlay",
+        "type": "capability",
+        "name": "semantic_overlay",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/agent-machine",
+        "type": "repo",
+        "name": "agent-machine",
+        "org": "SourceOS-Linux",
+        "authority_role": "machine_local_ai_runtime",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_machine",
+        "type": "capability",
+        "name": "agent_machine",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_pod",
+        "type": "capability",
+        "name": "agent_pod",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:inference_provider",
+        "type": "capability",
+        "name": "inference_provider",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:model_residency",
+        "type": "capability",
+        "name": "model_residency",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:placement_fact",
+        "type": "capability",
+        "name": "placement_fact",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_machine_receipt",
+        "type": "capability",
+        "name": "agent_machine_receipt",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/TurtleTerm",
+        "type": "repo",
+        "name": "TurtleTerm",
+        "org": "SourceOS-Linux",
+        "authority_role": "trusted_terminal_workbench",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:trusted_terminal",
+        "type": "capability",
+        "name": "trusted_terminal",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:terminal_receipts",
+        "type": "capability",
+        "name": "terminal_receipts",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_gateway",
+        "type": "capability",
+        "name": "agent_gateway",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:skill_manifests",
+        "type": "capability",
+        "name": "skill_manifests",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/BearBrowser",
+        "type": "repo",
+        "name": "BearBrowser",
+        "org": "SourceOS-Linux",
+        "authority_role": "governed_browser_runtime",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:human_secure_browser",
+        "type": "capability",
+        "name": "human_secure_browser",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_browser_runtime",
+        "type": "capability",
+        "name": "agent_browser_runtime",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:browser_policy_profiles",
+        "type": "capability",
+        "name": "browser_policy_profiles",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:browser_automation_surface",
+        "type": "capability",
+        "name": "browser_automation_surface",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/agent-term",
+        "type": "repo",
+        "name": "agent-term",
+        "org": "SourceOS-Linux",
+        "authority_role": "terminal_native_operator_console",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:matrix_chatops",
+        "type": "capability",
+        "name": "matrix_chatops",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:operator_event_log",
+        "type": "capability",
+        "name": "operator_event_log",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:approval_threads",
+        "type": "capability",
+        "name": "approval_threads",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:agent_participant_registry",
+        "type": "capability",
+        "name": "agent_participant_registry",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/sourceos-devtools",
+        "type": "repo",
+        "name": "sourceos-devtools",
+        "org": "SourceOS-Linux",
+        "authority_role": "sourceosctl_operator_cli",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:sourceosctl",
+        "type": "capability",
+        "name": "sourceosctl",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:dry_run_plans",
+        "type": "capability",
+        "name": "dry_run_plans",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:evidence_inspection",
+        "type": "capability",
+        "name": "evidence_inspection",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:guarded_local_execution",
+        "type": "capability",
+        "name": "guarded_local_execution",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/sourceos-model-carry",
+        "type": "repo",
+        "name": "sourceos-model-carry",
+        "org": "SourceOS-Linux",
+        "authority_role": "on_device_ai_service_carry",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:signed_model_refs",
+        "type": "capability",
+        "name": "signed_model_refs",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:local_model_profiles",
+        "type": "capability",
+        "name": "local_model_profiles",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:model_cache_policy",
+        "type": "capability",
+        "name": "model_cache_policy",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:boot_release_bindings",
+        "type": "capability",
+        "name": "boot_release_bindings",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/homebrew-tap",
+        "type": "repo",
+        "name": "homebrew-tap",
+        "org": "SourceOS-Linux",
+        "authority_role": "sourceos_homebrew_distribution",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:homebrew_formulae",
+        "type": "capability",
+        "name": "homebrew_formulae",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:install_surface",
+        "type": "capability",
+        "name": "install_surface",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SourceOS-Linux/librewolf-source-mirror",
+        "type": "repo",
+        "name": "librewolf-source-mirror",
+        "org": "SourceOS-Linux",
+        "authority_role": "browser_upstream_mirror",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:upstream_browser_source",
+        "type": "capability",
+        "name": "upstream_browser_source",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:browser_build_reference",
+        "type": "capability",
+        "name": "browser_build_reference",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/HolographMe",
+        "type": "repo",
+        "name": "HolographMe",
+        "org": "SocioProphet",
+        "authority_role": "self_owned_human_twin_governance",
+        "status": "active",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:human_twin_governance",
+        "type": "capability",
+        "name": "human_twin_governance",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:consent_policy",
+        "type": "capability",
+        "name": "consent_policy",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:capability_graph",
+        "type": "capability",
+        "name": "capability_graph",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:mission_fit_projection",
+        "type": "capability",
+        "name": "mission_fit_projection",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "repo:SocioProphet/smart-tree",
+        "type": "repo",
+        "name": "smart-tree",
+        "org": "SocioProphet",
+        "authority_role": "ai_friendly_repo_tree_inspection",
+        "status": "candidate",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:repo_tree_inspection",
+        "type": "capability",
+        "name": "repo_tree_inspection",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:mcp_tooling",
+        "type": "capability",
+        "name": "mcp_tooling",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:security_scan",
+        "type": "capability",
+        "name": "security_scan",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "id": "capability:context_compression",
+        "type": "capability",
+        "name": "context_compression",
+        "declared": true,
+        "verified": true
+      }
+    ],
+    "edges": [
+      {
+        "from": "repo:SocioProphet/socioprophet",
+        "to": "capability:web_portal",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet",
+        "to": "capability:api",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet",
+        "to": "capability:mcp_servers",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/workspace-inventory",
+        "to": "capability:repo_index",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/workspace-inventory",
+        "to": "capability:inventory_validation",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/workspace-inventory",
+        "to": "repo:SocioProphet/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "capability:workspace_manifest",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "capability:workspace_lock",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "capability:runner_semantics",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "repo:SocioProphet/workspace-inventory",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "repo:SocioProphet/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sociosphere",
+        "to": "repo:SocioProphet/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/agentplane",
+        "to": "capability:bundle_execution",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/agentplane",
+        "to": "capability:evidence_artifacts",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/agentplane",
+        "to": "capability:replay",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/agentplane",
+        "to": "repo:SocioProphet/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/agentplane",
+        "to": "repo:SocioProphet/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-platform",
+        "to": "capability:platform_apps",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-platform",
+        "to": "capability:contracts",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-platform",
+        "to": "capability:telemetry",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-platform",
+        "to": "repo:SocioProphet/socioprophet-standards-storage",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-platform",
+        "to": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-core-catalog",
+        "to": "capability:catalog",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-core-catalog",
+        "to": "capability:provenance_index",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-core-catalog",
+        "to": "repo:SocioProphet/gaia-world-model",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/prophet-core-catalog",
+        "to": "repo:SocioProphet/socioprophet-standards-storage",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/ontogenesis",
+        "to": "capability:capd:ontogenesis",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-storage",
+        "to": "capability:schemas",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-storage",
+        "to": "capability:evidence_contracts",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-storage",
+        "to": "capability:control_plane_standards",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "to": "capability:knowledge_schemas",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "to": "capability:tritrpc_bindings",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "to": "capability:roundtrip_verifiers",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "to": "repo:SocioProphet/tritrpc",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/socioprophet-standards-knowledge",
+        "to": "repo:SocioProphet/socioprophet-standards-storage",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/tritrpc",
+        "to": "capability:transport",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/tritrpc",
+        "to": "capability:fixtures",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/tritrpc",
+        "to": "capability:framing",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/sourceos-a2a-mcp-bootstrap",
+        "to": "capability:carrier_verify",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/human-digital-twin",
+        "to": "capability:api:hdt",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/human-digital-twin",
+        "to": "capability:opa:policies",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/human-digital-twin",
+        "to": "capability:tritrpc:devine",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/cloudshell-fog",
+        "to": "capability:cloud_shell",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/cloudshell-fog",
+        "to": "capability:operator_gateway",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/cloudshell-fog",
+        "to": "repo:SocioProphet/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/cloudshell-fog",
+        "to": "repo:SocioProphet/prophet-platform",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/SourceOS",
+        "to": "capability:substrate",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/SourceOS",
+        "to": "capability:truth_plane",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/SourceOS",
+        "to": "repo:SociOS-Linux/socios",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/SourceOS",
+        "to": "repo:SociOS-Linux/workstation-contracts",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/SourceOS",
+        "to": "repo:SociOS-Linux/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "capability:ci_cd",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "capability:build_automation",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "capability:catalogs",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "capability:signatures",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "repo:SociOS-Linux/SourceOS",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "repo:SociOS-Linux/workstation-contracts",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "repo:SociOS-Linux/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SociOS-Linux/socios",
+        "to": "repo:SociOS-Linux/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "capability:lane_contracts",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "capability:conformance",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "repo:SociOS-Linux/SourceOS",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "repo:SociOS-Linux/socios",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "repo:SociOS-Linux/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SociOS-Linux/workstation-contracts",
+        "to": "repo:SociOS-Linux/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-spec",
+        "to": "capability:json_schemas",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-spec",
+        "to": "capability:openapi_patches",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-spec",
+        "to": "capability:asyncapi_patches",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-spec",
+        "to": "capability:semantic_overlay",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:agent_machine",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:agent_pod",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:inference_provider",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:model_residency",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:placement_fact",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "capability:agent_machine_receipt",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "repo:SourceOS-Linux/sourceos-model-carry",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "repo:SourceOS-Linux/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "repo:SourceOS-Linux/policy-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "repo:SourceOS-Linux/model-router",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-machine",
+        "to": "repo:SourceOS-Linux/sourceos-devtools",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "capability:trusted_terminal",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "capability:terminal_receipts",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "capability:agent_gateway",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "capability:skill_manifests",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "repo:SourceOS-Linux/agent-term",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "repo:SourceOS-Linux/sourceos-devtools",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "repo:SourceOS-Linux/agent-machine",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "repo:SourceOS-Linux/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/TurtleTerm",
+        "to": "repo:SourceOS-Linux/policy-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "capability:human_secure_browser",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "capability:agent_browser_runtime",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "capability:browser_policy_profiles",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "capability:browser_automation_surface",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "repo:SourceOS-Linux/librewolf-source-mirror",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "repo:SourceOS-Linux/browser-use",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "repo:SourceOS-Linux/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "repo:SourceOS-Linux/policy-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/BearBrowser",
+        "to": "repo:SourceOS-Linux/sourceos-shell",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "capability:matrix_chatops",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "capability:operator_event_log",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "capability:approval_threads",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "capability:agent_participant_registry",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/agent-registry",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/policy-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/agentplane",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/memory-mesh-upstream",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/sherlock-search",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/agent-term",
+        "to": "repo:SourceOS-Linux/holmes",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "capability:sourceosctl",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "capability:dry_run_plans",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "capability:evidence_inspection",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "capability:guarded_local_execution",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/sourceos-model-carry",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/agent-machine",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/TurtleTerm",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/BearBrowser",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/model-router",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-devtools",
+        "to": "repo:SourceOS-Linux/guardrail-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "capability:signed_model_refs",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "capability:local_model_profiles",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "capability:model_cache_policy",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "capability:boot_release_bindings",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/model-router",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/model-governance-ledger",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/guardrail-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/sourceos-spec",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/sourceos-boot",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/sourceos-model-carry",
+        "to": "repo:SourceOS-Linux/agent-machine",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "capability:homebrew_formulae",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "capability:install_surface",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "repo:SourceOS-Linux/TurtleTerm",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "repo:SourceOS-Linux/BearBrowser",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "repo:SourceOS-Linux/agent-machine",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/homebrew-tap",
+        "to": "repo:SourceOS-Linux/sourceos-devtools",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/librewolf-source-mirror",
+        "to": "capability:upstream_browser_source",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/librewolf-source-mirror",
+        "to": "capability:browser_build_reference",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SourceOS-Linux/librewolf-source-mirror",
+        "to": "repo:SourceOS-Linux/BearBrowser",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "capability:human_twin_governance",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "capability:consent_policy",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "capability:capability_graph",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "capability:mission_fit_projection",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "repo:SocioProphet/human-digital-twin",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "repo:SocioProphet/agent-registry",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "repo:SocioProphet/policy-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "repo:SocioProphet/model-governance-ledger",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/HolographMe",
+        "to": "repo:SocioProphet/alexandrian-academy",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "capability:repo_tree_inspection",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "capability:mcp_tooling",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "capability:security_scan",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "capability:context_compression",
+        "type": "provides",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "repo:SocioProphet/workspace-inventory",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "repo:SocioProphet/sociosphere",
+        "type": "related_to",
+        "declared": true,
+        "verified": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "repo:SocioProphet/guardrail-fabric",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      },
+      {
+        "from": "repo:SocioProphet/smart-tree",
+        "to": "repo:SocioProphet/sourceos-devtools",
+        "type": "related_to",
+        "declared": true,
+        "verified": false,
+        "to_unresolved": true
+      }
+    ]
+  },
+  "summary": {
+    "declared": {
+      "K": 109,
+      "E": 156
+    },
+    "verified": {
+      "K": 109,
+      "E": 120
+    },
+    "by_type": {
+      "repo_nodes": 27,
+      "capability_nodes": 82,
+      "provides_edges": 82,
+      "related_to_edges": 74
+    },
+    "unresolved_related_repos": [
+      "repo:SocioProphet/sourceos-spec",
+      "repo:SocioProphet/sourceos-spec",
+      "repo:SocioProphet/gaia-world-model",
+      "repo:SociOS-Linux/sourceos-spec",
+      "repo:SociOS-Linux/sourceos-spec",
+      "repo:SociOS-Linux/sociosphere",
+      "repo:SociOS-Linux/sociosphere",
+      "repo:SociOS-Linux/sourceos-spec",
+      "repo:SourceOS-Linux/agentplane",
+      "repo:SourceOS-Linux/policy-fabric",
+      "repo:SourceOS-Linux/model-router",
+      "repo:SourceOS-Linux/agentplane",
+      "repo:SourceOS-Linux/policy-fabric",
+      "repo:SourceOS-Linux/browser-use",
+      "repo:SourceOS-Linux/agentplane",
+      "repo:SourceOS-Linux/policy-fabric",
+      "repo:SourceOS-Linux/sourceos-shell",
+      "repo:SourceOS-Linux/agent-registry",
+      "repo:SourceOS-Linux/sociosphere",
+      "repo:SourceOS-Linux/policy-fabric",
+      "repo:SourceOS-Linux/agentplane",
+      "repo:SourceOS-Linux/memory-mesh-upstream",
+      "repo:SourceOS-Linux/sherlock-search",
+      "repo:SourceOS-Linux/holmes",
+      "repo:SourceOS-Linux/model-router",
+      "repo:SourceOS-Linux/guardrail-fabric",
+      "repo:SourceOS-Linux/model-router",
+      "repo:SourceOS-Linux/model-governance-ledger",
+      "repo:SourceOS-Linux/guardrail-fabric",
+      "repo:SourceOS-Linux/sourceos-boot",
+      "repo:SocioProphet/agent-registry",
+      "repo:SocioProphet/policy-fabric",
+      "repo:SocioProphet/model-governance-ledger",
+      "repo:SocioProphet/alexandrian-academy",
+      "repo:SocioProphet/guardrail-fabric",
+      "repo:SocioProphet/sourceos-devtools"
+    ],
+    "unverified_repos": []
+  }
+}

--- a/scoreboards/kmass-org-twin-layer1-2026-08-04.json
+++ b/scoreboards/kmass-org-twin-layer1-2026-08-04.json
@@ -1,0 +1,311 @@
+{
+  "schemaVersion": "kmass.scoreboard.v0.1",
+  "recordType": "KmassScoreboard",
+  "recordId": "kmass-org-twin-layer1-2026-08-04",
+  "metricsContractRef": "docs/kmass-metrics-v1.md",
+  "measuredAt": "2026-08-04T02:50:00Z",
+  "environment": {
+    "name": "prophet-platform-prod",
+    "description": "Live GKE Autopilot cluster; measurements taken in-cluster against ClusterIP service DNS to exclude ingress/WAN variance.",
+    "clusterRef": "gke_socioprophet-platform_us-central1_prophet-platform"
+  },
+  "metrics": [
+    {
+      "metricId": "TAB.TEXT.GRAN",
+      "figureRow": "Textual Granularity",
+      "type": "Outcome",
+      "unit": "Top-1 accuracy @ unit",
+      "phaseTargets": {
+        "phase1": "80% @ document",
+        "phase2": "80% @ paragraph",
+        "phase3": "80% @ sentence"
+      },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Top-1 exact match against labeled target set, min 30 queries per phase per modality (contract \u00a7Measurement protocols)",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No labeled query/target set exists anywhere in the estate",
+        "No durable text corpus to evaluate against (see TAB.TEXT.SCALE)",
+        "search-orchestrator returns 0 results for all queries, so accuracy is undefined"
+      ],
+      "notes": "Accuracy cannot be defined while the retrieval path returns the empty set for every input. [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAB.VIDEO.GRAN",
+      "figureRow": "Video Granularity",
+      "type": "Outcome",
+      "unit": "Success@5 / Recall@5",
+      "phaseTargets": {
+        "phase1": "65% @ video",
+        "phase2": "65% @ 1-min clip",
+        "phase3": "65% @ frame"
+      },
+      "state": "UNBUILT",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Success@5 or Recall@5 with IoU threshold against labeled temporal target window",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No video, media, ASR, or transcode service exists in the cluster (verified: zero matching pods across all namespaces)",
+        "No media catalog or segment index",
+        "videolab/imagelab/speechlab are lab repos, not deployed services"
+      ],
+      "notes": " [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAB.TEXT.SCALE",
+      "figureRow": "Text Sources",
+      "type": "Capacity",
+      "unit": "count",
+      "phaseTargets": {
+        "phase1": 20000,
+        "phase2": 120000,
+        "phase3": 800000
+      },
+      "state": "MEASURED",
+      "measuredValue": 12,
+      "sampleSize": null,
+      "measurementProtocol": "Sum of retrievable documents across all live index services, read from each service's own health/stats endpoint",
+      "evidenceArtifacts": [
+        "sherlock-engine /healthz -> {\"docs\":12,\"engine\":\"tantivy\",\"dense\":false}",
+        "commons-search /healthz -> {\"store\":\"memory\",\"count\":0}",
+        "memoryd /healthz -> {\"store\":{\"backend\":\"memory\",\"resource_count\":0,\"event_count\":0,\"memory_count\":0}}",
+        "search-orchestrator /v1/search/debug/config -> academy_repository.record_count=1421, mode=in-memory"
+      ],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [],
+      "notes": "12 retrievable documents against a Phase-1 target of 20,000 = 0.06%. The search-orchestrator additionally holds 1421 seeded academy records, but they are NOT retrievable (0 results for every query tried, all modes) so they are excluded from the retrievable count. Root cause is architectural, not volumetric: every store in the retrieval tier is non-durable (see finding: ephemeral-retrieval-tier). [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAB.VIDEO.SCALE",
+      "figureRow": "Video Sources",
+      "type": "Capacity",
+      "unit": "hours",
+      "phaseTargets": {
+        "phase1": 40,
+        "phase2": 220,
+        "phase3": 400
+      },
+      "state": "UNBUILT",
+      "measuredValue": 0,
+      "sampleSize": null,
+      "measurementProtocol": "Media catalog duration sum + segment index cardinality",
+      "evidenceArtifacts": [
+        "No video/media/ASR pods found in any namespace"
+      ],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No media ingest, catalog, or segment index capability is deployed"
+      ],
+      "notes": " [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAC.CAPTURE.FRICTION",
+      "figureRow": "Easy and Natural",
+      "type": "Friction",
+      "unit": "minutes / fact",
+      "phaseTargets": {
+        "phase1": 10,
+        "phase2": 5,
+        "phase3": 2
+      },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Timestamped capture traces, min n=30 per contract sampling rule",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No capture-trace instrumentation exists in goose-notes or any capture surface",
+        "No deployed capture endpoint in-cluster to time against"
+      ],
+      "notes": "goose-notes is the designated capture surface but is not deployed to the measured environment and emits no timing traces. [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAD.LATENCY.JIT",
+      "figureRow": "Just-in-Time",
+      "type": "Outcome",
+      "unit": "seconds",
+      "phaseTargets": {
+        "phase1": 60,
+        "phase2": 8,
+        "phase3": 1
+      },
+      "state": "MEASURED",
+      "measuredValue": 0.0088,
+      "sampleSize": 30,
+      "measurementProtocol": "End-to-end query-to-answer completion, 30 distinct queries, in-cluster to exclude ingress variance",
+      "evidenceArtifacts": [
+        "search-orchestrator /v0/search/query: n=30 mean=8.7ms p50=8.8ms p95=9.4ms ok=30/30",
+        "sherlock-engine /search: n=30 mean=9.1ms p50=6.9ms p95=8.3ms"
+      ],
+      "runLog": "docs/reports/kmass-baseline-readout-2026-08-01.md#run-log",
+      "phaseClaim": "none",
+      "vacuousPass": true,
+      "blockedBy": [],
+      "notes": "VACUOUS PASS. p50 of 8.8ms nominally beats even the Phase-3 target of 1 second by ~113x, but every one of the 30 queries returned zero results. Latency over an empty result set measures nothing. This value MUST NOT be reported as a Phase-3 claim; it must be re-measured once retrieval returns real results. [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAD.ACTIONS.JE",
+      "figureRow": "Just-enough",
+      "type": "Friction",
+      "unit": "action count",
+      "phaseTargets": {
+        "phase1": 10,
+        "phase2": 5,
+        "phase3": 1
+      },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Discrete user or agent actions required to reach an acceptable answer state",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "Undefined while no query path reaches an 'acceptable answer state' (0 results for all queries)",
+        "No action instrumentation on any UI or agent surface"
+      ],
+      "notes": " [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "TAD.RELEVANCE.JFM",
+      "figureRow": "Just-for-me",
+      "type": "Outcome",
+      "unit": "percent relevant",
+      "phaseTargets": {
+        "phase1": 70,
+        "phase2": 83,
+        "phase3": 98
+      },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Blinded human evaluation, 0-3 rubric, score >= 2 counts relevant",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "No results to evaluate (0 results returned for all queries)",
+        "No blinded evaluation harness or rubric instrument exists",
+        "No per-actor personalization signal is wired into the query path"
+      ],
+      "notes": " [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "SYS.SPEEDUP",
+      "figureRow": "Speed Improvement",
+      "type": "Composite",
+      "unit": "multiplier",
+      "phaseTargets": {
+        "phase1": "1.1x",
+        "phase2": "2x",
+        "phase3": "5x"
+      },
+      "state": "UNMEASURED",
+      "measuredValue": null,
+      "sampleSize": null,
+      "measurementProtocol": "Time-on-task studies against a control condition",
+      "evidenceArtifacts": [],
+      "runLog": null,
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "A speedup multiplier requires a baseline control condition, which has never been established",
+        "Depends on TAD.LATENCY.JIT and TAD.ACTIONS.JE being non-vacuous first"
+      ],
+      "notes": " [Carried forward unchanged from kmass-baseline-2026-08-01; not re-measured in this run.]"
+    },
+    {
+      "metricId": "SYS.SCALE.TBD",
+      "figureRow": "Scale",
+      "type": "Composite",
+      "unit": "multi-dimensional",
+      "phaseTargets": {
+        "phase1": null,
+        "phase2": null,
+        "phase3": null
+      },
+      "state": "MEASURED",
+      "measuredValue": "K_verified=109 E_verified=120 (K_declared=109 E_declared=156; P_task/CoP/throughput unmeasured)",
+      "sampleSize": 27,
+      "measurementProtocol": "Policy/task/role graph statistics: |K| knowledge elements, |E| relations, |P(task)| policies per task, |CoP| communities of practice and role distributions, task throughput by role",
+      "evidenceArtifacts": [
+        "scoreboards/artifacts/org-twin-layer1-2026-08-04.json"
+      ],
+      "runLog": "tools/org_twin_layer1_extractor.py --out scoreboards/artifacts/org-twin-layer1-2026-08-04.json",
+      "phaseClaim": "none",
+      "vacuousPass": false,
+      "blockedBy": [
+        "|P(task)|, |CoP|, and role throughput are Layer 2 (work/policy overlay) -- not built yet, so this row is a PARTIAL measurement of |K| and |E| only",
+        "Phase targets are still TBD/TBD/TBD in the contract -- a measured baseline exists now to set them from, but they have not been set"
+      ],
+      "notes": "First real measurement of this row (previously fully UNMEASURED). Layer 1 inventory graph only: |K|=109, |E|=120 verified (each of workspace-inventory's 27 declared repos confirmed to exist via a live gh api probe, not trusted from the YAML alone -- all 27 verified this run). 36 declared related_to edges point at repos this same inventory file does not itself catalogue as an entry (e.g. sourceos-spec, agentplane, policy-fabric, model-router) -- a genuine finding about workspace-inventory's own incompleteness, not a bug in the extractor. |P(task)|, |CoP|, and throughput remain unmeasured pending Layer 2. See docs/design/org-digital-twin-v0.md."
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "summary": "The entire retrieval tier is non-durable; no corpus can accumulate.",
+      "detail": "Zero PersistentVolumeClaims back any retrieval service. sherlock-engine's tantivy index lives on an emptyDir capped at 256Mi. commons-search reports store=memory. memoryd reports backend=memory. search-orchestrator's academy repository reports mode=in-memory with json_file/lampstand_jsonl/lampstand_carrier all false. Every pod restart resets the corpus to zero. Growth targets of 20k -> 120k -> 800k documents are unreachable by construction, not by effort.",
+      "evidence": "kubectl get pvc -A (no retrieval PVCs); pod volume spec shows tmp -> emptyDir{sizeLimit:256Mi}; service /healthz payloads"
+    },
+    {
+      "severity": "critical",
+      "summary": "search-orchestrator returns zero results for every query, despite holding 1421 seeded records.",
+      "detail": "30 diverse queries plus generic probes ('a', 'the', 'learning', '*', empty string) across modes default/semantic/keyword/hybrid/all all returned results: []. Its own counter academy_result_total remained 0 while search_query_total advanced to 30. The seeded corpus (academy_seed_total=1421) is not connected to the retrieval path.",
+      "evidence": "POST /v0/search/query x30 -> 0 nonzero; /v1/search/debug/metrics before/after delta = {search_query_total: +30} only"
+    },
+    {
+      "severity": "critical",
+      "summary": "The search policy gate has never fired -- not once, including under this measurement run.",
+      "detail": "policy_decision_allow_total, _deny_total, _local_total, _remote_total and _fallback_total were all 0 before the run and all still 0 after 30 successful queries. A policy gate that does not evaluate on the request path is declared, not enforced. This is the estate's 'never-fired = SUSPECT' pattern in its purest form.",
+      "evidence": "/v1/search/debug/metrics before/after this scoreboard's own 30-query run"
+    },
+    {
+      "severity": "high",
+      "summary": "search_query_total was zero for the entire lifetime of the current pod before this run.",
+      "detail": "The current search-orchestrator pod was 3d2h old with 0 restarts, and search_query_total read exactly 0 before this run's 30 queries. The metric is process-local (mode=in-memory throughout this service), so this proves zero traffic for at least that pod's 3+ day lifetime -- it does NOT prove zero traffic since the Deployment's creation (2026-07-13, ~3 weeks prior); an earlier pod incarnation could have served queries before this one started. Either way, uptime and green health checks were reporting success against a path with no evidence of use for at least 3 days.",
+      "evidence": "kubectl get pod: restarts=0, age=3d2h; /v1/search/debug/metrics initial read: search_query_total=0; deployment creationTimestamp=2026-07-13T17:47:47Z (not directly comparable to the in-memory counter)"
+    },
+    {
+      "severity": "high",
+      "summary": "Latency 'passes' Phase 3 by 113x, and the pass is meaningless.",
+      "detail": "p50 8.8ms against a Phase-3 target of 1s. Because every query returns the empty set, this measures the cost of returning nothing. Recorded with vacuousPass=true so it cannot be counted toward a phase claim. This is precisely the silent-wrong class the contract's confidence rules exist to catch.",
+      "evidence": "n=30, nonzero-result=0/30"
+    },
+    {
+      "severity": "info",
+      "summary": "Two components are genuinely healthy and doing real work.",
+      "detail": "The embeddings service serves nomic-embed-text-v1.5 at 768 dimensions with p50 103ms over 10 samples. sherlock-engine's tantivy index answers in p50 6.9ms and returned non-empty results for 14 of 30 queries against its 12 documents -- small, but real retrieval. These are the two load-bearing pieces to build on.",
+      "evidence": "embeddings /healthz + /v1/embeddings n=10; sherlock /search n=30, 14 nonzero"
+    }
+  ],
+  "provenance": {
+    "createdBy": "org-digital-twin-layer1/2026-08-04",
+    "createdAt": "2026-08-04T02:50:00Z",
+    "nonSecret": true,
+    "method": "tools/org_twin_layer1_extractor.py run against workspace-inventory/inventory/repos.yaml (27 declared repo entries), with each repo node live-probed via `gh api repos/:org/:repo` (not trusted from the declaration alone). |K| and |E| reported are the VERIFIED subgraph, per docs/design/org-digital-twin-v0.md's declared-vs-verified honesty constraint. Full graph + summary in scoreboards/artifacts/org-twin-layer1-2026-08-04.json. Only SYS.SCALE changed in this record -- every other metric is carried forward unchanged from kmass-baseline-2026-08-01 and was NOT re-measured in this run (see notes on each row); this record exists specifically to give SYS.SCALE a second, different scoreboard so trend becomes visible (WO-KMASS-01's own definition of done), not to re-certify the rest of the estate."
+  },
+  "labels": {
+    "program": "kmass",
+    "runType": "org-twin-layer1",
+    "phase": "pre-phase-1"
+  }
+}

--- a/tools/org_twin_layer1_extractor.py
+++ b/tools/org_twin_layer1_extractor.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Org digital twin, Layer 1 -- the inventory graph.
+
+See docs/design/org-digital-twin-v0.md. This is the "first concrete step": a
+read-only extractor over workspace-inventory/repos.yaml plus a live `gh` probe,
+producing a graph and the |K| / |E| variables for the SYS.SCALE metric row.
+
+Layer 1 is deliberately narrow. It does NOT model tasks, policies, roles, or
+throughput (that is Layer 2). It models exactly what repos.yaml already
+declares -- repos, their declared capabilities (`provides`), and their declared
+relationships (`related_repos`) -- and then checks each repo against the real
+GitHub API rather than trusting the declaration.
+
+Declared vs verified (docs/design/org-digital-twin-v0.md's honesty constraint):
+a repo node that repos.yaml lists but that does not actually exist on GitHub is
+a hypothesis, not a fact. This extractor renders that distinction explicitly
+rather than silently trusting the file. |K| and |E| are reported for the FULL
+declared graph and separately for the VERIFIED-only subgraph -- the scoreboard
+should cite the verified numbers, not the declared ones, exactly as the design
+doc requires ("An edge that has never been probed is a hypothesis, not a
+fact").
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+
+def load_repos_yaml(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def gh_repo_exists(org: str, name: str) -> bool:
+    """Live probe: does this repo actually exist on GitHub? Fail-closed --
+    anything other than a clean success (network error, auth error, timeout)
+    is treated as NOT verified, never silently assumed to exist."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{org}/{name}"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def build_graph(data: dict, probe: Callable[[str, str], bool]) -> dict:
+    """Build the Layer 1 graph. `probe` is injectable so tests can run without
+    hitting the network."""
+    default_org = data.get("org", "")
+    repos = data.get("repos", [])
+
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+
+    for r in repos:
+        name = r["name"]
+        org = r.get("org", default_org)
+        repo_key = f"repo:{org}/{name}"
+        verified = probe(org, name)
+        nodes[repo_key] = {
+            "id": repo_key,
+            "type": "repo",
+            "name": name,
+            "org": org,
+            "authority_role": r.get("authority_role"),
+            "status": r.get("status"),
+            "declared": True,
+            "verified": verified,
+        }
+
+        for cap in r.get("provides", []) or []:
+            cap_key = f"capability:{cap}"
+            if cap_key not in nodes:
+                nodes[cap_key] = {
+                    "id": cap_key,
+                    "type": "capability",
+                    "name": cap,
+                    "declared": True,
+                    # A capability node's "verification" is inherited from
+                    # whether the repo that provides it was itself verified --
+                    # a capability declared by a nonexistent repo is exactly as
+                    # much a hypothesis as the repo is.
+                    "verified": False,
+                }
+            if verified:
+                nodes[cap_key]["verified"] = True
+            edges.append(
+                {
+                    "from": repo_key,
+                    "to": cap_key,
+                    "type": "provides",
+                    "declared": True,
+                    "verified": verified,
+                }
+            )
+
+        for related in r.get("related_repos", []) or []:
+            # related_repos entries are bare names (same org, per schema.json);
+            # the target may or may not itself be a repo declared elsewhere in
+            # this file -- resolve lazily below, once every repo is loaded.
+            edges.append(
+                {
+                    "from": repo_key,
+                    "to": f"repo:{org}/{related}",
+                    "type": "related_to",
+                    "declared": True,
+                    "verified": None,  # resolved below
+                }
+            )
+
+    # Resolve related_to edge verification now that all repo nodes exist:
+    # verified only if BOTH endpoints are verified repo nodes.
+    for e in edges:
+        if e["type"] == "related_to":
+            target = nodes.get(e["to"])
+            source = nodes.get(e["from"])
+            e["verified"] = bool(
+                source and source.get("verified") and target and target.get("verified")
+            )
+            if target is None:
+                # related_repos pointed at a name repos.yaml never declared as
+                # its own entry -- record it as an unresolved reference, not a
+                # silent drop.
+                e["to_unresolved"] = True
+
+    return {"nodes": list(nodes.values()), "edges": edges}
+
+
+def summarize(graph: dict) -> dict:
+    nodes = graph["nodes"]
+    edges = graph["edges"]
+    verified_nodes = [n for n in nodes if n["verified"]]
+    verified_edges = [e for e in edges if e.get("verified")]
+    return {
+        "declared": {"K": len(nodes), "E": len(edges)},
+        "verified": {"K": len(verified_nodes), "E": len(verified_edges)},
+        "by_type": {
+            "repo_nodes": len([n for n in nodes if n["type"] == "repo"]),
+            "capability_nodes": len([n for n in nodes if n["type"] == "capability"]),
+            "provides_edges": len([e for e in edges if e["type"] == "provides"]),
+            "related_to_edges": len([e for e in edges if e["type"] == "related_to"]),
+        },
+        "unresolved_related_repos": [e["to"] for e in edges if e.get("to_unresolved")],
+        "unverified_repos": [n["id"] for n in nodes if n["type"] == "repo" and not n["verified"]],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--repos-yaml",
+        type=Path,
+        default=Path.home() / "dev" / "workspace-inventory" / "inventory" / "repos.yaml",
+        help="Path to workspace-inventory's repos.yaml",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the full graph JSON here (nodes+edges). Prints the summary to stdout regardless.",
+    )
+    ap.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip live gh probes; treat nothing as verified (for local dry runs without network/auth).",
+    )
+    args = ap.parse_args()
+
+    if not args.repos_yaml.exists():
+        print(f"::error::repos.yaml not found at {args.repos_yaml}", file=sys.stderr)
+        return 1
+
+    data = load_repos_yaml(args.repos_yaml)
+    probe = (lambda org, name: False) if args.offline else gh_repo_exists
+    graph = build_graph(data, probe)
+    summary = summarize(graph)
+
+    print(json.dumps(summary, indent=2))
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump({"graph": graph, "summary": summary}, f, indent=2)
+        print(f"wrote full graph to {args.out}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_org_twin_layer1_extractor.py
+++ b/tools/tests/test_org_twin_layer1_extractor.py
@@ -1,0 +1,138 @@
+"""Adversarial proof that org_twin_layer1_extractor distinguishes declared from
+verified -- the honesty constraint docs/design/org-digital-twin-v0.md requires.
+Fires both ways: a repo that exists must be verified, one that doesn't must not,
+and a capability's/edge's verification must depend on its actual repo's
+verification, not on the declaration alone.
+
+Local-only, stdlib + the module under test. Does not touch the network -- the
+`gh` probe is injected as a fake.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from org_twin_layer1_extractor import build_graph, summarize  # noqa: E402
+
+FIXTURE = {
+    "workspace_inventory_version": 1,
+    "org": "SocioProphet",
+    "repos": [
+        {
+            "name": "real-repo",
+            "kind": "tool",
+            "manifest": "WORKSPACE.yaml",
+            "authority_role": "test",
+            "provides": ["shared-capability", "real-only-capability"],
+            "related_repos": ["ghost-repo"],
+        },
+        {
+            "name": "ghost-repo",  # declared here AND as a related_repos target,
+            # but the fake probe will report it does not exist -- proves an
+            # entry in repos.yaml itself can be unverified, not just a dangling
+            # reference.
+            "kind": "tool",
+            "manifest": "WORKSPACE.yaml",
+            "authority_role": "test",
+            "provides": ["shared-capability"],
+        },
+    ],
+}
+
+
+def fake_probe_real_only(org: str, name: str) -> bool:
+    return name == "real-repo"
+
+
+def test_verified_and_declared_diverge_correctly():
+    graph = build_graph(FIXTURE, fake_probe_real_only)
+    nodes = {n["id"]: n for n in graph["nodes"]}
+
+    assert nodes["repo:SocioProphet/real-repo"]["verified"] is True
+    assert nodes["repo:SocioProphet/ghost-repo"]["verified"] is False
+
+    # A capability provided ONLY by the ghost repo must not be verified.
+    assert nodes["capability:real-only-capability"]["verified"] is True
+    assert nodes["capability:shared-capability"]["verified"] is True  # real-repo also provides it
+
+    # related_to edge from real-repo -> ghost-repo must be unverified: BOTH
+    # endpoints must be verified for the edge to be verified, not just one.
+    related_edges = [e for e in graph["edges"] if e["type"] == "related_to"]
+    assert len(related_edges) == 1
+    assert related_edges[0]["verified"] is False
+
+
+def test_summary_counts_declared_vs_verified_separately():
+    graph = build_graph(FIXTURE, fake_probe_real_only)
+    summary = summarize(graph)
+
+    # Declared: 2 repos + 2 capability nodes (shared, real-only) = 4 nodes.
+    assert summary["declared"]["K"] == 4
+    # Verified: only real-repo's repo node + both capabilities it provides
+    # (shared-capability is verified because real-repo, a verified repo, also
+    # provides it) = 3.
+    assert summary["verified"]["K"] == 3
+    assert "repo:SocioProphet/ghost-repo" in summary["unverified_repos"]
+    assert "repo:SocioProphet/real-repo" not in summary["unverified_repos"]
+
+
+def fake_probe_none_exist(org: str, name: str) -> bool:
+    return False
+
+
+def test_fires_when_nothing_verifies():
+    """The other direction: if the probe reports nothing exists (e.g. the
+    --offline mode, or a real outage), verified counts must drop to zero, not
+    silently fall back to "assume declared == verified"."""
+    graph = build_graph(FIXTURE, fake_probe_none_exist)
+    summary = summarize(graph)
+    assert summary["verified"]["K"] == 0
+    assert summary["verified"]["E"] == 0
+    assert set(summary["unverified_repos"]) == {
+        "repo:SocioProphet/real-repo",
+        "repo:SocioProphet/ghost-repo",
+    }
+
+
+def fake_probe_all_exist(org: str, name: str) -> bool:
+    return True
+
+
+def test_fires_when_everything_verifies():
+    graph = build_graph(FIXTURE, fake_probe_all_exist)
+    summary = summarize(graph)
+    assert summary["verified"]["K"] == summary["declared"]["K"]
+    assert summary["verified"]["E"] == summary["declared"]["E"]
+    assert summary["unverified_repos"] == []
+
+
+def test_unresolved_related_repos_target_is_flagged_not_silently_dropped():
+    fixture = {
+        "org": "SocioProphet",
+        "repos": [
+            {
+                "name": "lonely-repo",
+                "kind": "tool",
+                "manifest": "WORKSPACE.yaml",
+                "related_repos": ["never-declared-anywhere"],
+            }
+        ],
+    }
+    graph = build_graph(fixture, fake_probe_all_exist)
+    summary = summarize(graph)
+    assert "repo:SocioProphet/never-declared-anywhere" in summary["unresolved_related_repos"]
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in list(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
## Why

`SYS.SCALE.TBD` is the only row in the KMASS metric contract with fully
undefined phase targets (TBD/TBD/TBD) — its variables (`|K|`, `|E|`,
`|P(task)|`, `|CoP|`, throughput) describe the organization itself, not a
service, so there was no way to fill it by instrumenting anything. See
`docs/design/org-digital-twin-v0.md`.

## What

Layer 1 ("first concrete step" per the design doc): `tools/org_twin_layer1_extractor.py`
reads `workspace-inventory/inventory/repos.yaml` and live-probes each declared
repo via `gh api repos/:org/:repo` — it does not trust the YAML declaration
alone. Emits a graph (repo nodes, capability nodes from `provides`, edges from
`provides` and `related_repos`) and a summary reporting `|K|`/`|E|` for both
the full declared graph and the verified-only subgraph.

**Honesty constraint enforced, not just described**: a repo/capability/edge is
only `verified` if it's actually confirmed live — adversarial test suite
(`tools/tests/test_org_twin_layer1_extractor.py`) proves this fires both ways
(nothing silently verified, nothing silently unverified), plus flags
`related_repos` targets the inventory doesn't itself catalogue as an entry.

## Real measurement

Ran against the current 27-repo inventory: **K=109, E=120 verified** (all 27
declared repos confirmed live; 36 of 156 declared edges point at repos this
same file doesn't catalogue as an entry — e.g. `sourceos-spec`, `agentplane`,
`policy-fabric`, `model-router` — a genuine finding about the inventory's own
incompleteness, not a bug in the extractor).

New scoreboard `scoreboards/kmass-org-twin-layer1-2026-08-04.json` updates
only the `SYS.SCALE` row to `MEASURED` (partial — `|P(task)|`/`|CoP|`/
throughput are Layer 2, not built yet); every other metric is carried forward
unchanged and explicitly marked as such. This gives `SYS.SCALE` its first
trend point, which is WO-KMASS-01's own definition of done ("a second
scoreboard exists").

## Verified

- `python3 tools/validate_kmass_scoreboard.py` — both scoreboards valid.
- `python3 tools/tests/test_org_twin_layer1_extractor.py` — 5/5 pass.
- Full `validate-contracts` suite (orggov/computational-artifact/ioes
  validators) still green.